### PR TITLE
fix(ssd_cache): use mlx-native safetensors so bf16 KV models can spill

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ claude
 ### Throughput & memory
 - **Continuous batching**: high throughput for concurrent requests
 - **Paged KV cache**: memory-efficient with prefix sharing
-- **SSD-tiered KV cache**: spill prefix cache to disk for long-context agents (`--ssd-cache-dir`)
+- **SSD-tiered KV cache**: spill prefix cache to disk for long-context agents (`--ssd-cache-dir`). Bf16-safe via MLX-native safetensors ([#2](https://github.com/akaszubski/vllm-mlx/pull/2), fixes [#1](https://github.com/akaszubski/vllm-mlx/issues/1)).
 - **Warm prompts**: preload popular prefixes at startup (`--warm-prompts`) for 1.3-2.25x TTFT
 - **Prefix cache**: trie-based, shared across requests
 

--- a/tests/test_ssd_cache.py
+++ b/tests/test_ssd_cache.py
@@ -213,16 +213,17 @@ from vllm_mlx.ssd_cache import (
 )
 
 
-class MockMLXArray:
-    """Minimal mock for MLX array with shape, dtype, and numpy conversion."""
+def MockMLXArray(data):
+    """Return a real mlx.core.array.
 
-    def __init__(self, data):
-        self._data = np.array(data)
-        self.shape = self._data.shape
-        self.dtype = type("dtype", (), {"size": self._data.dtype.itemsize})()
+    Originally a numpy-backed duck-typed mock, but the serializer now uses
+    mx.save_safetensors which needs a real mlx.core.array. The MLX array's
+    own .shape and .dtype.size attributes provide the same surface the mock
+    exposed, so call sites that read those still work unchanged.
+    """
+    import mlx.core as mx
 
-    def __array__(self):
-        return self._data
+    return mx.array(np.asarray(data))
 
 
 class MockKVCacheLayer:
@@ -292,6 +293,45 @@ class TestLayerSerializer:
             np.array(restored["state"][0]),
             np.array(arr0),
         )
+
+    def test_kv_cache_serializer_bf16_round_trip(self, tmp_path):
+        # Regression: production models (e.g. Qwen3-Coder-30B) hold KV in
+        # bfloat16. The previous safetensors.numpy path crashed because
+        # numpy has no native bf16 dtype. Must round-trip losslessly.
+        import mlx.core as mx
+
+        keys = mx.random.normal((1, 8, 32, 64)).astype(mx.bfloat16)
+        values = mx.random.normal((1, 8, 32, 64)).astype(mx.bfloat16)
+        mx.eval(keys, values)
+        layer = MockKVCacheLayer(keys=keys, values=values, offset=32)
+
+        serializer = KVCacheSerializer()
+        file_path = str(tmp_path / "layer_bf16.safetensors")
+        metadata = serializer.serialize_layer(layer, 0, file_path)
+
+        restored = serializer.deserialize_layer(file_path, metadata)
+        assert restored["keys"].dtype == mx.bfloat16
+        assert restored["values"].dtype == mx.bfloat16
+        assert mx.array_equal(restored["keys"], keys).item()
+        assert mx.array_equal(restored["values"], values).item()
+
+    def test_arrays_cache_serializer_bf16_round_trip(self, tmp_path):
+        import mlx.core as mx
+
+        arr0 = mx.random.normal((1, 64, 128)).astype(mx.bfloat16)
+        arr1 = mx.random.normal((1, 64, 128)).astype(mx.bfloat16)
+        mx.eval(arr0, arr1)
+        layer = MockArraysCacheLayer(state=[arr0, arr1])
+
+        serializer = ArraysCacheSerializer()
+        file_path = str(tmp_path / "arrays_bf16.safetensors")
+        metadata = serializer.serialize_layer(layer, 0, file_path)
+
+        restored = serializer.deserialize_layer(file_path, metadata)
+        assert len(restored["state"]) == 2
+        assert restored["state"][0].dtype == mx.bfloat16
+        assert mx.array_equal(restored["state"][0], arr0).item()
+        assert mx.array_equal(restored["state"][1], arr1).item()
 
     def test_get_serializer_for_kvcache(self):
         layer = MockKVCacheLayer(keys=None, values=None, offset=0)

--- a/vllm_mlx/ssd_cache.py
+++ b/vllm_mlx/ssd_cache.py
@@ -418,16 +418,18 @@ class KVCacheSerializer(LayerSerializer):
     def serialize_layer(
         self, layer: Any, layer_idx: int, file_path: str
     ) -> dict[str, Any]:
-        from safetensors.numpy import save_file
+        # Use MLX-native safetensors. safetensors.numpy chokes on bfloat16
+        # because numpy has no native bf16 dtype and MLX's PEP-3118 buffer
+        # for bf16 reports format='B' with itemsize=2, which numpy rejects.
+        import mlx.core as mx
 
-        keys_np = np.array(layer.keys)
-        values_np = np.array(layer.values)
-
-        tensors = {
-            f"layer_{layer_idx}_keys": keys_np,
-            f"layer_{layer_idx}_values": values_np,
-        }
-        save_file(tensors, file_path)
+        mx.save_safetensors(
+            file_path,
+            {
+                f"layer_{layer_idx}_keys": layer.keys,
+                f"layer_{layer_idx}_values": layer.values,
+            },
+        )
 
         metadata = {
             "layer_type": "KVCache",
@@ -442,10 +444,10 @@ class KVCacheSerializer(LayerSerializer):
         return metadata
 
     def deserialize_layer(self, file_path: str, metadata: dict[str, Any]) -> dict:
-        from safetensors.numpy import load_file
+        import mlx.core as mx
 
         layer_idx = metadata["layer_idx"]
-        tensors = load_file(file_path)
+        tensors = mx.load(file_path)
 
         result = {
             "keys": tensors[f"layer_{layer_idx}_keys"],
@@ -467,14 +469,13 @@ class ArraysCacheSerializer(LayerSerializer):
     def serialize_layer(
         self, layer: Any, layer_idx: int, file_path: str
     ) -> dict[str, Any]:
-        from safetensors.numpy import save_file
+        import mlx.core as mx
 
         state = layer.state
-        tensors = {}
-        for i, arr in enumerate(state):
-            tensors[f"layer_{layer_idx}_state_{i}"] = np.array(arr)
-
-        save_file(tensors, file_path)
+        tensors = {
+            f"layer_{layer_idx}_state_{i}": arr for i, arr in enumerate(state)
+        }
+        mx.save_safetensors(file_path, tensors)
 
         return {
             "layer_type": "ArraysCache",
@@ -483,11 +484,11 @@ class ArraysCacheSerializer(LayerSerializer):
         }
 
     def deserialize_layer(self, file_path: str, metadata: dict[str, Any]) -> dict:
-        from safetensors.numpy import load_file
+        import mlx.core as mx
 
         layer_idx = metadata["layer_idx"]
         num_arrays = metadata["num_arrays"]
-        tensors = load_file(file_path)
+        tensors = mx.load(file_path)
 
         state = []
         for i in range(num_arrays):
@@ -607,6 +608,24 @@ class SSDCacheTier:
 
         Returns True if enqueued, False if queue is full (entry dropped).
         """
+        # Materialise on the caller's stream before handoff. MLX arrays are
+        # bound to the stream that allocated them; if the writer thread later
+        # forces evaluation on its own stream we get
+        # "Stream(gpu, N) not in current thread" → libc++abi terminate.
+        try:
+            import mlx.core as mx
+
+            for layer in cache:
+                if hasattr(layer, "keys") and getattr(layer, "keys", None) is not None:
+                    mx.eval(layer.keys, layer.values)
+                elif hasattr(layer, "state"):
+                    state = layer.state
+                    if state:
+                        mx.eval(*state)
+        except Exception:
+            logger.exception("[ssd_cache] failed to materialise layers before spill")
+            return False
+
         try:
             self._spill_queue.put_nowait((tokens, cache, memory_bytes))
             return True


### PR DESCRIPTION
Closes #1

## What

`KVCacheSerializer` and `ArraysCacheSerializer` now go through `mx.save_safetensors` / `mx.load` instead of `safetensors.numpy`, and `SSDCacheTier.enqueue_spill` materialises layers on the caller's stream before handoff to the writer thread.

## Why

`safetensors.numpy` cannot serialise `bfloat16` (NumPy has no native bf16). Production models like Qwen3-Coder-30B store KV in bf16, so any spill crashed with a `RuntimeError` in the writer thread. That raise tripped a secondary MLX stream-binding violation (`Stream(gpu, N) not in current thread`) which terminated the whole process via uncaught C++ exception. See #1 for full traceback and root-cause analysis.

## How

- `vllm_mlx/ssd_cache.py`:
  - `KVCacheSerializer.{serialize,deserialize}_layer` use `mx.save_safetensors` / `mx.load`
  - `ArraysCacheSerializer.{serialize,deserialize}_layer` same
  - `SSDCacheTier.enqueue_spill` calls `mx.eval(...)` on each layer before queueing, so the writer thread only ever sees materialised arrays
- `tests/test_ssd_cache.py`:
  - `MockMLXArray` becomes a thin factory returning a real `mx.array` (the duck-typed numpy mock was hiding the production dtype)
  - Two new regression tests: `test_kv_cache_serializer_bf16_round_trip`, `test_arrays_cache_serializer_bf16_round_trip`

## Test plan

- [x] `pytest tests/test_ssd_cache.py -p no:homeassistant` → 55/55 pass
- [x] Standalone E2E: writer-thread + bf16 spill + `async_promote` round-trip → lossless (`mx.array_equal == True`), `ssd_hit_rate=1.0`
- [x] Live `localclaude` server with SSD cache enabled, Qwen3-Coder-30B, 10+ requests, 1 real spill, 0 errors

## Diff

87 lines added, 28 removed across two files.
