### PR TITLE
feat(weight-transfer): MLXWeightTransferEngine for RLHF/GRPO weight hot-reload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,27 @@
+# Changelog
+
+All notable user-visible changes to vllm-mlx are documented here.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/);
+this project adheres to [Semantic Versioning](https://semver.org/).
+
+## [Unreleased]
+
+### Added
+
+- MLX-backend `WeightTransferEngine` for RLHF/GRPO weight hot-reload.
+  Registers via `WeightTransferEngineFactory.register_engine('mlx', ...)`
+  with lazy import so non-Apple-Silicon installs are unaffected. (realign#1307, realign#1309)
+- 7 new HTTP routes mirroring upstream vLLM async-RL surface (all auth-gated):
+  `POST /init_weight_transfer_engine`, `POST /start_weight_update`,
+  `POST /update_weights`, `POST /finish_weight_update`, `POST /pause`,
+  `POST /resume`, `GET /get_world_size`. (realign#1309)
+- `Scheduler.pause(mode, clear_cache, timeout_s)` and `Scheduler.resume()`
+  with `mode in {'abort', 'wait', 'keep'}` matching upstream semantics. (realign#1309)
+- Pydantic request models: `WeightTransferInitRequest`,
+  `StartWeightUpdateRequest`, `WeightTransferUpdateRequest`, `PauseRequest`
+  in `vllm_mlx/api/models.py`. (realign#1309)
+
+> **Note**: Trainer-level end-to-end (`realign train --reload-every 1`) and LoRA +
+> grad-step deadlock validation are tracked separately (realign#1309 follow-up);
+> out of scope for this patch.

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ claude
 - **MoE expert reduction**: `--moe-top-k` for +7-16% on Qwen3-30B-A3B
 - **Speculative decoding**: `--mtp` for Qwen3-Next
 - **Sparse prefill**: attention-based `--spec-prefill` for TTFT reduction
+- **RLHF/GRPO weight hot-reload**: 7 trainer-facing HTTP routes (`/init_weight_transfer_engine`, `/update_weights`, `/pause`, `/resume`, etc.) mirror upstream vLLM async-RL surface for colocated training
 
 ### Observability
 - **Prometheus metrics**: `/metrics` endpoint with `--metrics`

--- a/docs/guides/server.md
+++ b/docs/guides/server.md
@@ -545,6 +545,48 @@ Per-request fields in `requests`:
 | `generated_tokens` | Tokens generated so far |
 | `max_tokens` | Maximum tokens requested |
 
+### Weight Transfer / RLHF Routes
+
+Seven root-level routes (no `/v1` prefix) mirror the upstream vLLM async-RL HTTP surface and enable GRPO/RLHF weight hot-reloading from a colocated trainer. All routes require API key authentication when `--api-key` is set.
+
+| Route | Method | Description |
+|-------|--------|-------------|
+| `/init_weight_transfer_engine` | POST | Initialize the MLX weight-transfer engine |
+| `/start_weight_update` | POST | Pause scheduling and clear caches before a weight update |
+| `/update_weights` | POST | Apply one weight update via the registered transfer engine |
+| `/finish_weight_update` | POST | Resume scheduling after a weight update completes |
+| `/pause` | POST | Pause the scheduler (`mode`: `abort`, `wait`, or `keep`) |
+| `/resume` | POST | Resume the scheduler after a pause |
+| `/get_world_size` | GET | Return world size (always 1 for single-host MLX) |
+
+**Pause modes** (set via `mode` field in `POST /pause`):
+
+| Mode | Behavior |
+|------|----------|
+| `wait` (default) | Drain in-flight requests up to `timeout_s`, then pause |
+| `abort` | Immediately abort all running requests and pause |
+| `keep` | Pause the scheduler but leave running requests untouched |
+
+Example — start a weight-update cycle:
+
+```bash
+# 1. Pause scheduling and clear caches
+curl -X POST http://localhost:8000/start_weight_update \
+  -H "Authorization: Bearer $API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"is_checkpoint_format": true}'
+
+# 2. Push updated weights
+curl -X POST http://localhost:8000/update_weights \
+  -H "Authorization: Bearer $API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"update_info": {"names": ["model.layers.0.self_attn.q_proj.weight"], "dtype_names": ["bfloat16"], "shapes": [[4096, 4096]], "path": "/tmp/weights"}}'
+
+# 3. Resume scheduling
+curl -X POST http://localhost:8000/finish_weight_update \
+  -H "Authorization: Bearer $API_KEY"
+```
+
 ## Tool Calling
 
 Enable OpenAI-compatible tool calling with `--enable-auto-tool-choice`:

--- a/tests/test_weight_transfer_mlx.py
+++ b/tests/test_weight_transfer_mlx.py
@@ -1,0 +1,775 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for the MLX WeightTransferEngine (Plan-1.5 Patch #3).
+
+Test ID conventions follow plan section 5:
+- test_factory_lazy_registration      (AC-1)
+- test_scheduler_pause_*              (AC-2)
+- test_engine_clear_kv_and_prefix_cache (AC-3)
+- test_ten_cycle_no_memory_growth     (AC-4, Apple Silicon only)
+- test_precompiled_kernel_survives_update (AC-5)
+- test_trainer_send_weights_eval_barrier (AC-6)
+- test_routes_*                        (AC-7)
+- test_pydantic_*                      (AC-8)
+- test_changelog_unreleased_entry      (AC-9)
+- test_integration_real_model_rollout  (skipped — OUT OF SCOPE)
+"""
+
+from __future__ import annotations
+
+import gc
+import platform
+import sys
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi.testclient import TestClient
+
+# ---------------------------------------------------------------------------
+# Module-under-test imports
+# ---------------------------------------------------------------------------
+
+import mlx.core as mx
+import mlx.nn as nn
+
+import vllm_mlx.server as srv
+from vllm_mlx.api.models import (
+    PauseRequest,
+    StartWeightUpdateRequest,
+    WeightTransferInitRequest,
+    WeightTransferUpdateRequest,
+)
+from vllm_mlx.weight_transfer import (
+    MLXWeightTransferInitInfo,
+    MLXWeightTransferUpdateInfo,
+    WeightTransferEngine,
+    WeightTransferEngineFactory,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_safetensors_file(arrays: dict) -> str:
+    """Write `arrays` to a temp safetensors file; return path."""
+    tmp = tempfile.NamedTemporaryFile(
+        suffix=".safetensors", delete=False
+    )
+    tmp.close()
+    mx.save_safetensors(tmp.name, arrays)
+    return tmp.name
+
+
+# ---------------------------------------------------------------------------
+# AC-1: Factory lazy registration
+# ---------------------------------------------------------------------------
+
+
+class TestFactoryLazyRegistration:
+    """Factory holds module/class strings; first get_engine_class imports."""
+
+    def test_factory_lazy_registration(self) -> None:
+        # registry holds 2-tuple of strings before any import
+        assert "mlx" in WeightTransferEngineFactory._registry
+        module_path, class_name = WeightTransferEngineFactory._registry["mlx"]
+        assert isinstance(module_path, str)
+        assert isinstance(class_name, str)
+        assert module_path == "vllm_mlx.weight_transfer.mlx_backend"
+        assert class_name == "MLXWeightTransferEngine"
+
+        # First resolution triggers import, second call returns cached.
+        cls1 = WeightTransferEngineFactory.get_engine_class("mlx")
+        cls2 = WeightTransferEngineFactory.get_engine_class("mlx")
+        assert cls1 is cls2
+        assert issubclass(cls1, WeightTransferEngine)
+
+    def test_factory_unknown_backend_raises(self) -> None:
+        with pytest.raises(KeyError, match="No weight-transfer backend"):
+            WeightTransferEngineFactory.get_engine_class("does-not-exist")
+
+
+# ---------------------------------------------------------------------------
+# AC-2: Scheduler pause/resume
+# ---------------------------------------------------------------------------
+
+
+def _make_scheduler_without_init():
+    """Construct a Scheduler without invoking heavy __init__.
+
+    We skip the real __init__ (which would build a BatchGenerator etc.) by
+    creating a bare instance and stubbing in just the fields pause() touches.
+    """
+    from vllm_mlx.scheduler import Scheduler
+    import threading
+
+    sched = Scheduler.__new__(Scheduler)
+    sched.running = {}
+    sched.waiting = []
+    sched.finished_req_ids = set()
+    sched._paused = False
+    sched._pause_mode = None
+    sched._pause_lock = threading.Lock()
+    sched._inflight_drained = threading.Event()
+    sched._inflight_drained.set()
+    return sched
+
+
+class TestSchedulerPauseResume:
+    def test_scheduler_pause_wait_no_inflight(self) -> None:
+        sched = _make_scheduler_without_init()
+        result = sched.pause(mode="wait", clear_cache=True, timeout_s=0.5)
+        assert result["paused"] is True
+        assert result["drained"] is True
+        assert result["mode"] == "wait"
+        assert result["clear_cache_requested"] is True
+        assert sched._paused is True
+
+    def test_scheduler_pause_abort_cancels_inflight(self) -> None:
+        from vllm_mlx.request import RequestStatus
+
+        sched = _make_scheduler_without_init()
+        # Populate fake running requests.
+        for rid in ("req-a", "req-b"):
+            req = MagicMock()
+            req.request_id = rid
+            req.status = RequestStatus.RUNNING
+            req.finish_reason = None
+            sched.running[rid] = req
+
+        result = sched.pause(mode="abort", clear_cache=False, timeout_s=0.5)
+        assert result["mode"] == "abort"
+        assert sched.running == {}
+        assert "req-a" in sched.finished_req_ids
+        assert "req-b" in sched.finished_req_ids
+        # All previously running requests must be marked FINISHED_ABORTED.
+        # (We mutated the original mock objects in-place.)
+        # No direct access to the request objects anymore — they were removed.
+        # Verify _paused and mode set.
+        assert sched._paused is True
+        assert sched._pause_mode == "abort"
+
+    def test_scheduler_pause_keep_freezes(self) -> None:
+        sched = _make_scheduler_without_init()
+        req = MagicMock(request_id="r1")
+        sched.running["r1"] = req
+        result = sched.pause(mode="keep", clear_cache=False, timeout_s=0.5)
+        assert result["mode"] == "keep"
+        assert "r1" in sched.running  # not modified
+        assert sched._paused is True
+
+    def test_scheduler_pause_invalid_mode(self) -> None:
+        sched = _make_scheduler_without_init()
+        with pytest.raises(ValueError, match="unknown pause mode"):
+            sched.pause(mode="garbage")
+
+    def test_scheduler_resume(self) -> None:
+        sched = _make_scheduler_without_init()
+        sched.pause(mode="keep", clear_cache=False)
+        result = sched.resume()
+        assert result["resumed"] is True
+        assert result["previous_mode"] == "keep"
+        assert sched._paused is False
+
+    def test_scheduler_step_returns_empty_when_paused(self) -> None:
+        """When paused, step() must return an empty SchedulerOutput safely."""
+        from vllm_mlx.scheduler import SchedulerOutput
+
+        sched = _make_scheduler_without_init()
+        sched.pause(mode="keep", clear_cache=False)
+        out = sched.step()
+        assert isinstance(out, SchedulerOutput)
+        assert getattr(out, "outputs", []) == []
+        assert getattr(out, "scheduled_request_ids", []) == []
+
+
+# ---------------------------------------------------------------------------
+# AC-3: Engine clear KV + prefix cache shim
+# ---------------------------------------------------------------------------
+
+
+class TestEngineClearCache:
+    def test_engine_clear_kv_and_prefix_cache(self) -> None:
+        """The shim must call both scheduler.clear_runtime_caches and
+        scheduler.clear_prefix_cache."""
+        from vllm_mlx.engine_core import EngineCore
+
+        engine = EngineCore.__new__(EngineCore)
+        engine.scheduler = MagicMock()
+        engine.scheduler.clear_runtime_caches = MagicMock(return_value={})
+        engine.scheduler.clear_prefix_cache = MagicMock(return_value=None)
+
+        engine.clear_kv_and_prefix_cache()
+        engine.scheduler.clear_runtime_caches.assert_called_once()
+        engine.scheduler.clear_prefix_cache.assert_called_once()
+
+    def test_engine_clear_cache_tolerates_missing_prefix_method(self) -> None:
+        """If scheduler lacks clear_prefix_cache, the shim still succeeds."""
+        from vllm_mlx.engine_core import EngineCore
+
+        engine = EngineCore.__new__(EngineCore)
+        sched = MagicMock(spec=["clear_runtime_caches"])
+        sched.clear_runtime_caches = MagicMock(return_value={})
+        engine.scheduler = sched
+
+        engine.clear_kv_and_prefix_cache()  # must not raise
+        sched.clear_runtime_caches.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# AC-4: 10-cycle memory growth bound
+# ---------------------------------------------------------------------------
+
+
+_IS_APPLE_SILICON = (
+    platform.system() == "Darwin" and platform.machine() == "arm64"
+)
+
+
+@pytest.mark.skipif(
+    not _IS_APPLE_SILICON, reason="MLX weight transfer requires Apple Silicon"
+)
+def test_ten_cycle_no_memory_growth() -> None:
+    """10 cycles of update on a tiny model must not balloon process RSS.
+
+    Threshold: <= 16 MiB delta over 10 iterations.
+    """
+    import resource
+
+    model = nn.Linear(8, 8)
+    cls = WeightTransferEngineFactory.get_engine_class("mlx")
+    engine = cls(config=None, parallel_config=None, model=model)
+    engine.init_transfer_engine(MLXWeightTransferInitInfo(world_size=1))
+
+    def _load_weights(params_list):
+        params_dict = dict(params_list)
+        model.update(params_dict)
+        mx.eval(model.parameters())
+
+    rss_before = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+
+    for _ in range(10):
+        # Make a fresh set of params with same shapes.
+        new_w = mx.random.normal(shape=(8, 8))
+        new_b = mx.random.normal(shape=(8,))
+        path = _make_safetensors_file({"weight": new_w, "bias": new_b})
+        try:
+            info = MLXWeightTransferUpdateInfo(
+                names=["weight", "bias"],
+                dtype_names=["float32", "float32"],
+                shapes=[[8, 8], [8]],
+                path=path,
+            )
+            engine.receive_weights(info, _load_weights)
+        finally:
+            Path(path).unlink(missing_ok=True)
+        gc.collect()
+
+    rss_after = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+
+    # Darwin reports ru_maxrss in bytes; Linux in KiB. Normalize to bytes.
+    if sys.platform == "linux":
+        rss_before *= 1024
+        rss_after *= 1024
+    delta_mib = (rss_after - rss_before) / (1024 * 1024)
+    # ru_maxrss is a *peak* watermark, so it can only grow. The 16 MiB
+    # epsilon must cover MLX's lazy allocator + safetensors I/O headroom.
+    assert delta_mib < 16, (
+        f"RSS growth {delta_mib:.2f} MiB exceeds 16 MiB bound over 10 cycles"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-5: Precompiled kernel survives weight update
+# ---------------------------------------------------------------------------
+
+
+def test_precompiled_kernel_survives_update() -> None:
+    """After model.update + mx.eval, a compiled forward still produces
+    a correctly-shaped output (no recompile crash).
+
+    Note: ``mx.compile`` of a closure captures parameter references at trace
+    time; the captured kernel is reused after update. The contract here is
+    that the kernel does NOT crash and the output shape is preserved.
+    Re-evaluation via ``model(x)`` directly will pick up new weights.
+    """
+    model = nn.Linear(8, 8)
+    compiled = mx.compile(lambda x: model(x))
+
+    x = mx.random.normal(shape=(2, 8))
+    y1 = compiled(x)
+    mx.eval(y1)
+    assert y1.shape == (2, 8)
+
+    # Update weights to a fresh init (zeros for determinism).
+    new_params = {
+        "weight": mx.zeros((8, 8)),
+        "bias": mx.zeros((8,)),
+    }
+    model.update(new_params)
+    mx.eval(model.parameters())
+
+    # The precompiled kernel must still execute without raising.
+    y2 = compiled(x)
+    mx.eval(y2)
+    assert y2.shape == (2, 8)
+
+    # Direct (uncompiled) call WILL see the new weights — sanity-check that
+    # the update itself took effect on the module's parameters.
+    y_direct = model(x)
+    mx.eval(y_direct)
+    assert y_direct.shape == (2, 8)
+    assert mx.allclose(y_direct, mx.zeros((2, 8))).item()
+
+
+# ---------------------------------------------------------------------------
+# AC-6: trainer_send_weights eval barrier + safetensors out
+# ---------------------------------------------------------------------------
+
+
+def test_trainer_send_weights_eval_barrier() -> None:
+    """A lazy array is fully evaluated before being written."""
+    cls = WeightTransferEngineFactory.get_engine_class("mlx")
+    a = mx.array([1.0, 2.0, 3.0])
+    b = mx.array([4.0, 5.0, 6.0])
+    lazy_sum = a + b  # lazy
+    weights = [("sum", lazy_sum)]
+
+    with tempfile.NamedTemporaryFile(
+        suffix=".safetensors", delete=False
+    ) as tf:
+        out_path = tf.name
+
+    try:
+        cls.trainer_send_weights(iter(weights), {"out_path": out_path})
+        assert Path(out_path).exists()
+        loaded = mx.load(out_path)
+        assert "sum" in loaded
+        assert mx.allclose(loaded["sum"], mx.array([5.0, 7.0, 9.0])).item()
+    finally:
+        Path(out_path).unlink(missing_ok=True)
+
+
+def test_trainer_send_weights_no_out_path_raises() -> None:
+    cls = WeightTransferEngineFactory.get_engine_class("mlx")
+    with pytest.raises(NotImplementedError, match="out_path"):
+        cls.trainer_send_weights(iter([("x", mx.array([1.0]))]), {})
+
+
+# ---------------------------------------------------------------------------
+# AC-8: Pydantic schema validation
+# ---------------------------------------------------------------------------
+
+
+class TestPydanticSchemas:
+    def test_pydantic_init_request_permissive(self) -> None:
+        # Extra fields allowed (forward-compat with upstream NCCL etc.).
+        m = WeightTransferInitRequest(
+            init_info={"world_size": 1, "rank": 0},
+            nccl_uri="ignored",  # arbitrary extra
+        )
+        assert m.init_info["world_size"] == 1
+
+    def test_pydantic_update_request_missing_keys(self) -> None:
+        # missing 'names'
+        with pytest.raises(ValueError, match="missing required key"):
+            WeightTransferUpdateRequest(
+                update_info={
+                    "dtype_names": [],
+                    "shapes": [],
+                    "path": "/tmp/x",
+                }
+            )
+
+    def test_pydantic_update_request_length_mismatch(self) -> None:
+        with pytest.raises(ValueError, match="equal length"):
+            WeightTransferUpdateRequest(
+                update_info={
+                    "names": ["a"],
+                    "dtype_names": ["float32", "float32"],
+                    "shapes": [[1]],
+                    "path": "/tmp/x",
+                }
+            )
+
+    def test_pydantic_update_request_both_packed_and_path(self) -> None:
+        with pytest.raises(ValueError, match="exactly one of"):
+            WeightTransferUpdateRequest(
+                update_info={
+                    "names": [],
+                    "dtype_names": [],
+                    "shapes": [],
+                    "packed": b"x",
+                    "path": "/tmp/x",
+                }
+            )
+
+    def test_pydantic_update_request_neither_packed_nor_path(self) -> None:
+        with pytest.raises(ValueError, match="exactly one of"):
+            WeightTransferUpdateRequest(
+                update_info={
+                    "names": [],
+                    "dtype_names": [],
+                    "shapes": [],
+                }
+            )
+
+    def test_pydantic_pause_request_rejects_invalid_mode(self) -> None:
+        with pytest.raises(ValueError):
+            PauseRequest(mode="invalid")  # type: ignore[arg-type]
+
+    def test_pydantic_pause_request_defaults(self) -> None:
+        p = PauseRequest()
+        assert p.mode == "wait"
+        assert p.clear_cache is True
+
+    def test_pydantic_start_weight_update_defaults(self) -> None:
+        s = StartWeightUpdateRequest()
+        assert s.is_checkpoint_format is True
+
+
+# ---------------------------------------------------------------------------
+# AC-7: HTTP route auth + dispatch
+# ---------------------------------------------------------------------------
+
+
+_WT_ROUTES = [
+    ("POST", "/init_weight_transfer_engine", {"init_info": {"world_size": 1}}),
+    ("POST", "/start_weight_update", {"is_checkpoint_format": True}),
+    (
+        "POST",
+        "/update_weights",
+        {
+            "update_info": {
+                "names": [],
+                "dtype_names": [],
+                "shapes": [],
+                "path": "/tmp/x",
+            }
+        },
+    ),
+    ("POST", "/finish_weight_update", None),
+    ("POST", "/pause", {"mode": "wait", "clear_cache": True}),
+    ("POST", "/resume", None),
+    ("GET", "/get_world_size", None),
+]
+
+
+class TestRoutesAuthGate:
+    """When _api_key is set, every weight-transfer route must reject
+    unauthenticated requests."""
+
+    def test_routes_auth_gate(self) -> None:
+        client = TestClient(srv.app)
+        original_key = srv._api_key
+        original_engine = srv._engine
+        srv._api_key = "secret"
+        srv._engine = MagicMock()
+        try:
+            for method, path, body in _WT_ROUTES:
+                if method == "POST":
+                    resp = client.post(path, json=body)
+                else:
+                    resp = client.get(path)
+                assert resp.status_code in (401, 403), (
+                    f"{method} {path} returned {resp.status_code} "
+                    f"without auth — expected 401/403"
+                )
+        finally:
+            srv._api_key = original_key
+            srv._engine = original_engine
+
+
+class TestRoutesDispatch:
+    """When auth is off and an engine is mocked in, each route maps to the
+    correct engine shim with the correct args."""
+
+    def _patch_engine(self) -> MagicMock:
+        engine = MagicMock()
+        engine.init_weight_transfer_engine.return_value = {
+            "initialized": True,
+            "backend": "mlx",
+            "world_size": 1,
+        }
+        engine.start_weight_update.return_value = {"started": True}
+        engine.update_weights.return_value = {"applied": True}
+        engine.finish_weight_update.return_value = {"resumed": True}
+        engine.pause.return_value = {"paused": True}
+        engine.resume.return_value = {"resumed": True}
+        engine.get_world_size.return_value = 1
+        return engine
+
+    def test_init_route_dispatches(self) -> None:
+        client = TestClient(srv.app)
+        original_engine = srv._engine
+        original_key = srv._api_key
+        srv._engine = self._patch_engine()
+        srv._api_key = None
+        try:
+            r = client.post(
+                "/init_weight_transfer_engine",
+                json={"init_info": {"world_size": 1, "rank": 0}},
+            )
+            assert r.status_code == 200, r.text
+            srv._engine.init_weight_transfer_engine.assert_called_once()
+            # The route passes the Pydantic model in; verify shape.
+            call_arg = srv._engine.init_weight_transfer_engine.call_args[0][0]
+            assert call_arg.init_info["world_size"] == 1
+        finally:
+            srv._engine = original_engine
+            srv._api_key = original_key
+
+    def test_start_weight_update_route_dispatches(self) -> None:
+        client = TestClient(srv.app)
+        original_engine = srv._engine
+        original_key = srv._api_key
+        srv._engine = self._patch_engine()
+        srv._api_key = None
+        try:
+            r = client.post(
+                "/start_weight_update", json={"is_checkpoint_format": False}
+            )
+            assert r.status_code == 200, r.text
+            srv._engine.start_weight_update.assert_called_once_with(False)
+        finally:
+            srv._engine = original_engine
+            srv._api_key = original_key
+
+    def test_update_weights_route_dispatches(self) -> None:
+        client = TestClient(srv.app)
+        original_engine = srv._engine
+        original_key = srv._api_key
+        srv._engine = self._patch_engine()
+        srv._api_key = None
+        try:
+            r = client.post(
+                "/update_weights",
+                json={
+                    "update_info": {
+                        "names": ["weight"],
+                        "dtype_names": ["float32"],
+                        "shapes": [[8, 8]],
+                        "path": "/tmp/dummy.safetensors",
+                    }
+                },
+            )
+            assert r.status_code == 200, r.text
+            srv._engine.update_weights.assert_called_once()
+        finally:
+            srv._engine = original_engine
+            srv._api_key = original_key
+
+    def test_finish_weight_update_route_dispatches(self) -> None:
+        client = TestClient(srv.app)
+        original_engine = srv._engine
+        original_key = srv._api_key
+        srv._engine = self._patch_engine()
+        srv._api_key = None
+        try:
+            r = client.post("/finish_weight_update")
+            assert r.status_code == 200, r.text
+            srv._engine.finish_weight_update.assert_called_once()
+        finally:
+            srv._engine = original_engine
+            srv._api_key = original_key
+
+    def test_pause_route_dispatches(self) -> None:
+        client = TestClient(srv.app)
+        original_engine = srv._engine
+        original_key = srv._api_key
+        srv._engine = self._patch_engine()
+        srv._api_key = None
+        try:
+            r = client.post(
+                "/pause", json={"mode": "abort", "clear_cache": False}
+            )
+            assert r.status_code == 200, r.text
+            srv._engine.pause.assert_called_once_with(
+                mode="abort", clear_cache=False
+            )
+        finally:
+            srv._engine = original_engine
+            srv._api_key = original_key
+
+    def test_resume_route_dispatches(self) -> None:
+        client = TestClient(srv.app)
+        original_engine = srv._engine
+        original_key = srv._api_key
+        srv._engine = self._patch_engine()
+        srv._api_key = None
+        try:
+            r = client.post("/resume")
+            assert r.status_code == 200, r.text
+            srv._engine.resume.assert_called_once()
+        finally:
+            srv._engine = original_engine
+            srv._api_key = original_key
+
+    def test_get_world_size_route_dispatches(self) -> None:
+        client = TestClient(srv.app)
+        original_engine = srv._engine
+        original_key = srv._api_key
+        srv._engine = self._patch_engine()
+        srv._api_key = None
+        try:
+            r = client.get("/get_world_size")
+            assert r.status_code == 200, r.text
+            assert r.json() == {"world_size": 1}
+        finally:
+            srv._engine = original_engine
+            srv._api_key = original_key
+
+
+class TestUpdateWeightsReentrancyGuard:
+    """M-3 mitigation: update_weights must require prior start_weight_update.
+
+    Without an active weight-update window, the scheduler is not paused and
+    caches have not been cleared — applying weights would race in-flight
+    forward passes against model.update() on shared state.
+    """
+
+    def test_update_weights_without_start_raises(self) -> None:
+        from vllm_mlx.engine_core import EngineCore
+
+        engine = EngineCore.__new__(EngineCore)
+        # Pretend the transfer engine has been initialized so the first
+        # guard (engine is None) passes; the re-entrancy guard is the
+        # check under test.
+        engine._weight_transfer_engine = MagicMock()
+        engine._weight_update_in_progress = False
+
+        with pytest.raises(RuntimeError, match="start_weight_update"):
+            engine.update_weights(MagicMock())
+
+
+class TestRoutesEngineMissing:
+    """Each route must return 503 when engine isn't initialized."""
+
+    def test_routes_503_when_no_engine(self) -> None:
+        client = TestClient(srv.app)
+        original_engine = srv._engine
+        original_key = srv._api_key
+        srv._engine = None
+        srv._api_key = None
+        try:
+            for method, path, body in _WT_ROUTES:
+                if method == "POST":
+                    resp = client.post(path, json=body)
+                else:
+                    resp = client.get(path)
+                assert resp.status_code == 503, f"{method} {path} -> {resp.status_code}"
+        finally:
+            srv._engine = original_engine
+            srv._api_key = original_key
+
+
+# ---------------------------------------------------------------------------
+# AC-9: CHANGELOG entry
+# ---------------------------------------------------------------------------
+
+
+def test_changelog_unreleased_entry() -> None:
+    changelog = REPO_ROOT / "CHANGELOG.md"
+    assert changelog.exists(), f"CHANGELOG.md missing at {changelog}"
+    text = changelog.read_text(encoding="utf-8")
+    assert "## [Unreleased]" in text
+    assert "WeightTransferEngine" in text
+
+
+# ---------------------------------------------------------------------------
+# MLX backend behavioral tests
+# ---------------------------------------------------------------------------
+
+
+class TestMLXBackendBehavior:
+    def test_init_world_size_must_be_one(self) -> None:
+        cls = WeightTransferEngineFactory.get_engine_class("mlx")
+        engine = cls(config=None, parallel_config=None, model=MagicMock())
+        with pytest.raises(ValueError, match="world_size=1"):
+            engine.init_transfer_engine(MLXWeightTransferInitInfo(world_size=2))
+
+    def test_receive_weights_path_roundtrip(self) -> None:
+        model = nn.Linear(4, 4)
+        cls = WeightTransferEngineFactory.get_engine_class("mlx")
+        engine = cls(config=None, parallel_config=None, model=model)
+        engine.init_transfer_engine(MLXWeightTransferInitInfo(world_size=1))
+
+        new_w = mx.zeros((4, 4))
+        new_b = mx.zeros((4,))
+        path = _make_safetensors_file({"weight": new_w, "bias": new_b})
+
+        applied: list = []
+
+        def _load(params_list):
+            applied.extend(params_list)
+            model.update(dict(params_list))
+
+        try:
+            info = MLXWeightTransferUpdateInfo(
+                names=["weight", "bias"],
+                dtype_names=["float32", "float32"],
+                shapes=[[4, 4], [4]],
+                path=path,
+            )
+            engine.receive_weights(info, _load)
+        finally:
+            Path(path).unlink(missing_ok=True)
+
+        names = [n for n, _ in applied]
+        assert names == ["weight", "bias"]
+
+    def test_receive_weights_shape_mismatch_raises(self) -> None:
+        cls = WeightTransferEngineFactory.get_engine_class("mlx")
+        engine = cls(config=None, parallel_config=None, model=MagicMock())
+        engine.init_transfer_engine(MLXWeightTransferInitInfo(world_size=1))
+
+        path = _make_safetensors_file({"weight": mx.zeros((4, 4))})
+        try:
+            info = MLXWeightTransferUpdateInfo(
+                names=["weight"],
+                dtype_names=["float32"],
+                shapes=[[8, 8]],  # WRONG
+                path=path,
+            )
+            with pytest.raises(ValueError, match="shape mismatch"):
+                engine.receive_weights(info, lambda *_: None)
+        finally:
+            Path(path).unlink(missing_ok=True)
+
+    def test_receive_weights_rejects_both_path_and_packed(self) -> None:
+        cls = WeightTransferEngineFactory.get_engine_class("mlx")
+        engine = cls(config=None, parallel_config=None, model=MagicMock())
+        engine.init_transfer_engine(MLXWeightTransferInitInfo(world_size=1))
+
+        info = MLXWeightTransferUpdateInfo(
+            names=["x"],
+            dtype_names=["float32"],
+            shapes=[[1]],
+            path="/tmp/a",
+            packed=b"x",
+        )
+        with pytest.raises(ValueError, match="exactly one"):
+            engine.receive_weights(info, lambda *_: None)
+
+    def test_shutdown_idempotent(self) -> None:
+        cls = WeightTransferEngineFactory.get_engine_class("mlx")
+        engine = cls(config=None, parallel_config=None, model=MagicMock())
+        engine.init_transfer_engine(MLXWeightTransferInitInfo(world_size=1))
+        engine.shutdown()
+        engine.shutdown()  # second call must not raise
+
+
+# ---------------------------------------------------------------------------
+# Integration (skipped — OUT OF SCOPE per PROJECT.md)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skip(reason="integration; OUT OF SCOPE per PROJECT.md")
+def test_integration_real_model_rollout() -> None:  # pragma: no cover
+    """End-to-end: realign train --reload-every 1. Tracked separately
+    (realign#1309 follow-up)."""

--- a/vllm_mlx/api/models.py
+++ b/vllm_mlx/api/models.py
@@ -11,9 +11,15 @@ These models define the request and response schemas for:
 
 import time
 import uuid
-from typing import Any
+from typing import Any, Literal
 
-from pydantic import AliasChoices, BaseModel, Field, model_serializer
+from pydantic import (
+    AliasChoices,
+    BaseModel,
+    Field,
+    model_serializer,
+    model_validator,
+)
 
 # =============================================================================
 # Content Types (for multimodal messages)
@@ -541,3 +547,69 @@ class ChatCompletionChunk(BaseModel):
     model: str
     choices: list[ChatCompletionChunkChoice]
     usage: Usage | None = None  # Included when stream_options.include_usage=true
+
+
+# =============================================================================
+# Weight-transfer / RLHF surface (Plan-1.5 Patch #3)
+# =============================================================================
+
+
+class WeightTransferInitRequest(BaseModel):
+    """Init payload for the weight-transfer engine.
+
+    Permissive — accepts upstream NCCL/UCX fields without breaking single-host
+    MLX deployments. The MLX backend silently ignores unknown init_info keys.
+    """
+
+    model_config = {"extra": "allow"}
+    init_info: dict = Field(default_factory=dict)
+
+
+class StartWeightUpdateRequest(BaseModel):
+    """Optional payload for /start_weight_update."""
+
+    is_checkpoint_format: bool = True
+
+
+class WeightTransferUpdateRequest(BaseModel):
+    """Payload for /update_weights.
+
+    Validation enforces that ``update_info`` carries:
+      - parallel-length ``names``, ``dtype_names``, ``shapes`` lists
+      - exactly one of ``packed`` or ``path`` (never neither, never both).
+    """
+
+    update_info: dict = Field(...)
+
+    @model_validator(mode="after")
+    def _validate_update_info(self) -> "WeightTransferUpdateRequest":
+        info = self.update_info
+        for k in ("names", "dtype_names", "shapes"):
+            if k not in info:
+                raise ValueError(
+                    f"update_info missing required key: {k!r}\n"
+                    f"Expected keys: names, dtype_names, shapes, "
+                    f"and exactly one of (packed, path)."
+                )
+        if not isinstance(info["names"], list):
+            raise ValueError("update_info.names must be a list")
+        if len(info["names"]) != len(info["dtype_names"]) or len(
+            info["names"]
+        ) != len(info["shapes"]):
+            raise ValueError(
+                "update_info.names, dtype_names, shapes must be equal length"
+            )
+        has_packed = info.get("packed") is not None
+        has_path = info.get("path") is not None
+        if has_packed == has_path:
+            raise ValueError(
+                "update_info must set exactly one of 'packed' or 'path'"
+            )
+        return self
+
+
+class PauseRequest(BaseModel):
+    """Payload for /pause."""
+
+    mode: Literal["abort", "wait", "keep"] = "wait"
+    clear_cache: bool = True

--- a/vllm_mlx/engine_core.py
+++ b/vllm_mlx/engine_core.py
@@ -111,6 +111,12 @@ class EngineCore:
         self._start_time: Optional[float] = None
         self._steps_executed = 0
 
+        # Weight-transfer state (lazy: engine instance created on first
+        # init_weight_transfer_engine call). Forward-ref string to avoid
+        # importing the weight_transfer module at engine_core load time.
+        self._weight_transfer_engine: Optional["Any"] = None
+        self._weight_update_in_progress: bool = False
+
         logger.debug(f"Engine {self._engine_id} initialized")
 
     async def start(self) -> None:
@@ -638,6 +644,169 @@ class EngineCore:
         """Clear the prefix cache (delegates to scheduler)."""
         if hasattr(self.scheduler, "clear_prefix_cache"):
             self.scheduler.clear_prefix_cache()
+
+    # ------------------------------------------------------------------
+    # Weight-transfer surface (Plan-1.5 Patch #3)
+    # ------------------------------------------------------------------
+
+    def get_world_size(self) -> int:
+        """MLX runs single-host (Apple Silicon)."""
+        return 1
+
+    def pause(
+        self,
+        mode: str = "wait",
+        clear_cache: bool = True,
+        timeout_s: float = 30.0,
+    ) -> Dict[str, Any]:
+        """Pause scheduling; optionally clear KV/prefix caches afterward."""
+        result = self.scheduler.pause(
+            mode=mode, clear_cache=clear_cache, timeout_s=timeout_s
+        )
+        if result.get("clear_cache_requested"):
+            self.clear_kv_and_prefix_cache()
+        return result
+
+    def resume(self) -> Dict[str, Any]:
+        """Resume scheduling after a pause()."""
+        return self.scheduler.resume()
+
+    def clear_kv_and_prefix_cache(self) -> None:
+        """Invalidate KV (runtime) and prefix caches.
+
+        Delegates to existing scheduler-level hooks; both calls are
+        defensively wrapped so a backend-specific failure (e.g., paged
+        cache absent) doesn't take down the weight-update flow.
+        """
+        try:
+            self.scheduler.clear_runtime_caches()
+        except Exception as e:
+            logger.warning("clear_runtime_caches failed: %s", e)
+        if hasattr(self.scheduler, "clear_prefix_cache"):
+            try:
+                self.scheduler.clear_prefix_cache()
+            except Exception as e:
+                logger.warning("clear_prefix_cache failed: %s", e)
+
+    def init_weight_transfer_engine(self, req: Any) -> Dict[str, Any]:
+        """Create the MLX weight-transfer engine.
+
+        Idempotent — re-init replaces any existing engine instance.
+
+        Args:
+            req: Request object or dict with ``init_info`` (dict of init args).
+
+        Returns:
+            Dict with ``initialized``, ``backend``, ``world_size``.
+        """
+        # Lazy import — keeps mlx out of import chain on non-Apple hosts.
+        from vllm_mlx.weight_transfer import WeightTransferEngineFactory
+
+        backend = "mlx"
+        if hasattr(req, "init_info"):
+            init_dict = req.init_info or {}
+        elif isinstance(req, dict):
+            init_dict = req.get("init_info", {}) or {}
+        else:
+            init_dict = {}
+
+        engine_cls = WeightTransferEngineFactory.get_engine_class(backend)
+        init_info = engine_cls.parse_init_info(init_dict)
+        engine = WeightTransferEngineFactory.create_engine(
+            backend, self.config, None, self.scheduler.model
+        )
+        engine.init_transfer_engine(init_info)
+        self._weight_transfer_engine = engine
+        return {
+            "initialized": True,
+            "backend": backend,
+            "world_size": init_info.world_size,
+        }
+
+    def start_weight_update(
+        self, is_checkpoint_format: bool = True
+    ) -> Dict[str, Any]:
+        """Begin a weight update: pause + clear caches.
+
+        Re-entrancy: if an update is already in progress, this returns
+        ``{"started": False, ...}`` without modifying scheduler state.
+        """
+        if getattr(self, "_weight_update_in_progress", False):
+            return {
+                "started": False,
+                "reason": "update already in progress",
+            }
+        self._weight_update_in_progress = True
+        result = self.pause(mode="wait", clear_cache=True, timeout_s=30.0)
+        result["started"] = True
+        result["is_checkpoint_format"] = is_checkpoint_format
+        return result
+
+    def update_weights(self, req: Any) -> Dict[str, Any]:
+        """Apply one weight update via the registered transfer engine."""
+        engine = getattr(self, "_weight_transfer_engine", None)
+        if engine is None:
+            raise RuntimeError(
+                "Weight transfer engine not initialized; "
+                "call init_weight_transfer_engine first."
+            )
+        # M-3 mitigation: require an active weight-update window so the
+        # scheduler has been paused and caches cleared. Bypassing this
+        # would race model.update() against in-flight forward passes.
+        if not getattr(self, "_weight_update_in_progress", False):
+            raise RuntimeError(
+                "update_weights called without start_weight_update; "
+                "call start_weight_update first to pause the scheduler "
+                "and clear caches"
+            )
+        if hasattr(req, "update_info"):
+            update_dict = req.update_info
+        elif isinstance(req, dict):
+            update_dict = req.get("update_info")
+        else:
+            update_dict = None
+        if update_dict is None:
+            raise ValueError("update_weights: req.update_info is missing")
+
+        update_info = type(engine).parse_update_info(update_dict)
+        engine.receive_weights(update_info, load_weights=self._load_weights)
+        return {"applied": True, "num_params": len(update_info.names)}
+
+    def finish_weight_update(self) -> Dict[str, Any]:
+        """End a weight update: clear in-progress flag and resume scheduling."""
+        self._weight_update_in_progress = False
+        return self.resume()
+
+    def _load_weights(self, params_list: List[tuple]) -> None:
+        """Apply (name, mx.array) pairs to the model and force eval barrier.
+
+        Closure passed into `receive_weights`. This is where the actual
+        in-place update happens: `model.update(dict)` followed by
+        `mx.eval(model.parameters())` to materialize lazy ops.
+        """
+        params_dict = dict(params_list)
+        # L-1 mitigation: audit log every weight application. Surface
+        # parameter count and a sample of names so an operator can see
+        # exactly what the engine accepted from the trainer.
+        sorted_names = sorted(params_dict.keys())
+        sample = sorted_names[:5]
+        if len(sorted_names) > 5:
+            logger.info(
+                "Applying weight update: %d params, names=%s ... (+%d more)",
+                len(params_dict),
+                sample,
+                len(sorted_names) - 5,
+            )
+        else:
+            logger.info(
+                "Applying weight update: %d params, names=%s",
+                len(params_dict),
+                sample,
+            )
+        self.scheduler.model.update(params_dict)
+        # Force the lazy graph to materialize so the next forward pass sees
+        # the new weights deterministically.
+        mx.eval(self.scheduler.model.parameters())
 
     def _release_model(self) -> None:
         """Release model ownership."""

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -12,6 +12,8 @@ The scheduler follows vLLM's design with:
 """
 
 import logging
+import threading
+import time
 from collections import deque
 from dataclasses import dataclass, field
 from enum import Enum
@@ -1152,6 +1154,12 @@ class Scheduler:
         self.request_id_to_uid: Dict[str, int] = {}
         self.uid_to_request_id: Dict[int, str] = {}
 
+        # Pause/resume state — used by weight-transfer flow to freeze
+        # scheduling while weights are hot-swapped. See pause()/resume() below.
+        self._paused: bool = False
+        self._pause_mode: Optional[str] = None
+        self._pause_lock = threading.Lock()
+
         # BatchGenerator - the actual batching engine
         self.batch_generator: Optional[BatchGenerator] = None
         self._current_sampler_params: Optional[Tuple] = None
@@ -1854,6 +1862,96 @@ class Scheduler:
             f"Added request {request.request_id} with {request.num_prompt_tokens} prompt tokens"
         )
 
+    # ------------------------------------------------------------------
+    # Pause / resume (used by weight-transfer flow)
+    # ------------------------------------------------------------------
+
+    def pause(
+        self,
+        mode: str = "wait",
+        clear_cache: bool = True,
+        timeout_s: float = 30.0,
+    ) -> Dict[str, Any]:
+        """Pause request scheduling.
+
+        Args:
+            mode: One of:
+                - ``"wait"``: drain in-flight requests up to ``timeout_s``,
+                  then pause.
+                - ``"abort"``: mark all running requests FINISHED_ABORTED,
+                  clear running, then pause.
+                - ``"keep"``: freeze without modifying the running queue;
+                  ``resume()`` resumes from where we left off.
+            clear_cache: Whether the caller intends to clear KV/prefix caches
+                after pause. Reported back in the result so the engine can act.
+            timeout_s: Max seconds to wait for ``running`` to drain in
+                ``"wait"`` mode.
+
+        Returns:
+            Dict with keys ``paused``, ``mode``, ``drained``,
+            ``clear_cache_requested``, ``running_count``.
+
+        Raises:
+            ValueError: If ``mode`` is not one of the supported values.
+        """
+        if mode not in ("wait", "abort", "keep"):
+            raise ValueError(
+                f"unknown pause mode: {mode!r}\n"
+                f"Expected one of: 'wait', 'abort', 'keep'\n"
+                f"See: docs/guides/server.md#weight-transfer--rlhf-routes"
+            )
+        with self._pause_lock:
+            drained = True
+            if mode == "wait":
+                drained = self._drain_inflight(timeout_s)
+                if not drained:
+                    logger.warning(
+                        "Scheduler.pause(wait) timeout after %.1fs; "
+                        "%d still running",
+                        timeout_s,
+                        len(self.running),
+                    )
+            elif mode == "abort":
+                for req_id, req in list(self.running.items()):
+                    req.status = RequestStatus.FINISHED_ABORTED
+                    if hasattr(req, "finish_reason"):
+                        req.finish_reason = "aborted_for_weight_update"
+                    self.finished_req_ids.add(req_id)
+                self.running.clear()
+            # mode == "keep": leave running untouched.
+            self._paused = True
+            self._pause_mode = mode
+            return {
+                "paused": True,
+                "mode": mode,
+                "drained": drained,
+                "clear_cache_requested": clear_cache,
+                "running_count": len(self.running),
+            }
+
+    def resume(self) -> Dict[str, Any]:
+        """Resume request scheduling after a pause."""
+        with self._pause_lock:
+            was = self._pause_mode
+            self._paused = False
+            self._pause_mode = None
+            return {"resumed": True, "previous_mode": was}
+
+    def _drain_inflight(self, timeout_s: float) -> bool:
+        """Block until ``len(self.running) == 0`` or timeout.
+
+        Returns:
+            True if drained within ``timeout_s``, False if timed out.
+        """
+        if not self.running:
+            return True
+        deadline = time.monotonic() + timeout_s
+        while time.monotonic() < deadline:
+            if not self.running:
+                return True
+            time.sleep(0.01)
+        return not self.running
+
     def abort_request(self, request_id: str) -> bool:
         """
         Queue request for abort. Thread-safe, called from any thread.
@@ -2448,6 +2546,13 @@ class Scheduler:
         Returns:
             SchedulerOutput with results of this step
         """
+        # Short-circuit when paused — engine_core loop is expected to keep
+        # ticking while pause() is in effect (e.g., during weight updates).
+        # Return an empty SchedulerOutput so callers see "no work" without
+        # touching the BatchGenerator or running set.
+        if self._paused:
+            return SchedulerOutput()
+
         output = SchedulerOutput()
 
         # Process pending aborts FIRST (in executor thread, safe for MLX)

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -104,6 +104,10 @@ from .api.models import (
     ToolCall,
     Usage,  # noqa: F401
     VideoUrl,  # noqa: F401
+    WeightTransferInitRequest,
+    StartWeightUpdateRequest,
+    WeightTransferUpdateRequest,
+    PauseRequest,
 )
 from .api.responses_models import (
     ResponseCompletedEvent,
@@ -2977,6 +2981,75 @@ async def clear_prefix_cache():
 
     status = "cleared" if cleared else "not_supported"
     return {"status": status, "rewarm_scheduled": rewarm_scheduled}
+
+
+# =============================================================================
+# Weight-transfer / RLHF surface (Plan-1.5 Patch #3)
+# Root-level routes (no /v1 prefix) to mirror upstream vLLM async-RL surface.
+# =============================================================================
+
+
+@app.post(
+    "/init_weight_transfer_engine", dependencies=[Depends(verify_api_key)]
+)
+async def init_weight_transfer_engine(
+    req: WeightTransferInitRequest,
+) -> dict:
+    """Initialize the MLX weight-transfer engine."""
+    if _engine is None:
+        raise HTTPException(status_code=503, detail="Engine not initialized")
+    return _engine.init_weight_transfer_engine(req)
+
+
+@app.post("/start_weight_update", dependencies=[Depends(verify_api_key)])
+async def start_weight_update(
+    req: StartWeightUpdateRequest | None = None,
+) -> dict:
+    """Pause scheduling and clear caches in preparation for a weight update."""
+    if _engine is None:
+        raise HTTPException(status_code=503, detail="Engine not initialized")
+    is_ckpt = req.is_checkpoint_format if req is not None else True
+    return _engine.start_weight_update(is_ckpt)
+
+
+@app.post("/update_weights", dependencies=[Depends(verify_api_key)])
+async def update_weights(req: WeightTransferUpdateRequest) -> dict:
+    """Apply one weight update via the registered transfer engine."""
+    if _engine is None:
+        raise HTTPException(status_code=503, detail="Engine not initialized")
+    return _engine.update_weights(req)
+
+
+@app.post("/finish_weight_update", dependencies=[Depends(verify_api_key)])
+async def finish_weight_update() -> dict:
+    """Resume scheduling after a weight update."""
+    if _engine is None:
+        raise HTTPException(status_code=503, detail="Engine not initialized")
+    return _engine.finish_weight_update()
+
+
+@app.post("/pause", dependencies=[Depends(verify_api_key)])
+async def pause_scheduler(req: PauseRequest) -> dict:
+    """Pause scheduling (modes: wait, abort, keep)."""
+    if _engine is None:
+        raise HTTPException(status_code=503, detail="Engine not initialized")
+    return _engine.pause(mode=req.mode, clear_cache=req.clear_cache)
+
+
+@app.post("/resume", dependencies=[Depends(verify_api_key)])
+async def resume_scheduler() -> dict:
+    """Resume scheduling after a pause."""
+    if _engine is None:
+        raise HTTPException(status_code=503, detail="Engine not initialized")
+    return _engine.resume()
+
+
+@app.get("/get_world_size", dependencies=[Depends(verify_api_key)])
+async def get_world_size() -> dict:
+    """Return scheduler world size (always 1 for MLX, Apple-Silicon single-host)."""
+    if _engine is None:
+        raise HTTPException(status_code=503, detail="Engine not initialized")
+    return {"world_size": _engine.get_world_size()}
 
 
 @app.get("/v1/models", dependencies=[Depends(verify_api_key)])

--- a/vllm_mlx/weight_transfer/__init__.py
+++ b/vllm_mlx/weight_transfer/__init__.py
@@ -1,0 +1,40 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Weight-transfer package: abstract base + MLX backend.
+
+Importing this module registers the MLX backend with
+`WeightTransferEngineFactory` lazily (the factory holds module/class strings;
+the MLX backend module is only imported on first `create_engine('mlx', ...)`).
+"""
+
+from .base import (
+    WeightTransferEngine,
+    WeightTransferEngineFactory,
+    WeightTransferInitInfo,
+    WeightTransferUpdateInfo,
+)
+from .types import (
+    MLXWeightTransferInitInfo,
+    MLXWeightTransferUpdateInfo,
+)
+
+# Lazy registration — the mlx_backend module is NOT imported here.
+WeightTransferEngineFactory.register_engine(
+    "mlx",
+    "vllm_mlx.weight_transfer.mlx_backend",
+    "MLXWeightTransferEngine",
+)
+
+
+def _get_mlx_engine_class():
+    """Helper to materialize the MLX backend class (forces lazy import)."""
+    return WeightTransferEngineFactory.get_engine_class("mlx")
+
+
+__all__ = [
+    "WeightTransferEngine",
+    "WeightTransferEngineFactory",
+    "WeightTransferInitInfo",
+    "WeightTransferUpdateInfo",
+    "MLXWeightTransferInitInfo",
+    "MLXWeightTransferUpdateInfo",
+]

--- a/vllm_mlx/weight_transfer/base.py
+++ b/vllm_mlx/weight_transfer/base.py
@@ -1,0 +1,239 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Abstract WeightTransferEngine + Factory mirroring vllm-project/vllm v0.23+ interface.
+
+This file is the local copy of the upstream extension point. realign#1310 will
+contribute the MLX backend back to vllm-project/vllm and (potentially) remove
+this file in favor of importing from upstream — but until then, we own it here
+to keep the dependency footprint minimal.
+
+The interface intentionally mirrors upstream's `WeightTransferEngine` so the
+MLX backend can be contributed without re-shaping its API.
+"""
+
+from __future__ import annotations
+
+import importlib
+import threading
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from typing import (
+    Any,
+    Callable,
+    ClassVar,
+    Dict,
+    Generic,
+    Iterator,
+    Tuple,
+    Type,
+    TypeVar,
+)
+
+
+@dataclass
+class WeightTransferInitInfo:
+    """Base init info — backends extend with their own fields.
+
+    Attributes:
+        world_size: Number of ranks participating in the transfer. MLX runs
+            single-host only; >1 is reserved for upstream backends.
+        rank: This worker's rank in [0, world_size).
+        backend: Backend identifier (e.g., "mlx", "nccl"). Not the same as the
+            registry key, but typically matches.
+    """
+
+    world_size: int = 1
+    rank: int = 0
+    backend: str = ""
+
+
+@dataclass
+class WeightTransferUpdateInfo:
+    """Base update info — backends extend with their own fields.
+
+    Attributes:
+        names: Parameter names in the model namespace.
+        dtype_names: Per-parameter dtype names, parallel to `names`.
+        shapes: Per-parameter shapes (lists of ints), parallel to `names`.
+    """
+
+    names: list[str] = field(default_factory=list)
+    dtype_names: list[str] = field(default_factory=list)
+    shapes: list[list[int]] = field(default_factory=list)
+
+
+TInitInfo = TypeVar("TInitInfo", bound=WeightTransferInitInfo)
+TUpdateInfo = TypeVar("TUpdateInfo", bound=WeightTransferUpdateInfo)
+
+
+class WeightTransferEngine(ABC, Generic[TInitInfo, TUpdateInfo]):
+    """Abstract weight transfer engine.
+
+    Subclasses MUST:
+      - Set class attributes `init_info_cls` and `update_info_cls`.
+      - Implement `init_transfer_engine`, `receive_weights`, `shutdown`.
+      - Implement static `trainer_send_weights(iterator, trainer_args)`.
+
+    Subclasses MAY:
+      - Override `receive_sparse_weights` and `trainer_send_sparse_weights`
+        (default raises NotImplementedError).
+    """
+
+    init_info_cls: ClassVar[Type[WeightTransferInitInfo]]
+    update_info_cls: ClassVar[Type[WeightTransferUpdateInfo]]
+
+    def __init__(self, config: Any, parallel_config: Any, model: Any) -> None:
+        """Store engine context.
+
+        Args:
+            config: Engine-level config (vLLM EngineConfig or analog).
+            parallel_config: Parallel config (may be None on single-host).
+            model: The MLX/torch model whose parameters will be updated.
+        """
+        self._config = config
+        self._parallel_config = parallel_config
+        self._model = model
+
+    @abstractmethod
+    def init_transfer_engine(self, init_info: TInitInfo) -> None:
+        """Bring the transfer engine to ready state for a particular session."""
+
+    @abstractmethod
+    def receive_weights(
+        self,
+        update_info: TUpdateInfo,
+        load_weights: Callable[[list[Tuple[str, Any]]], None],
+    ) -> None:
+        """Receive one weight update and apply it via `load_weights`.
+
+        Args:
+            update_info: Per-update metadata (names/dtypes/shapes + payload pointer).
+            load_weights: Callable that does `model.update(dict)` + a barrier
+                (e.g., mx.eval). The backend MUST call this exactly once
+                with the materialized `[(name, array), ...]` pairs.
+        """
+
+    @abstractmethod
+    def shutdown(self) -> None:
+        """Release any per-session resources (sockets, buffers, threads)."""
+
+    @staticmethod
+    @abstractmethod
+    def trainer_send_weights(
+        iterator: Iterator[Tuple[str, Any]],
+        trainer_args: Dict[str, Any],
+    ) -> None:
+        """Trainer-side: serialize an iterator of (name, array) for transport."""
+
+    def receive_sparse_weights(
+        self,
+        update_info: Any,
+        apply_patches: Callable[..., None],
+    ) -> None:
+        """Optional: receive sparse weight patches (e.g., LoRA deltas)."""
+        raise NotImplementedError(
+            "Sparse weight transfer not implemented by this backend"
+        )
+
+    @staticmethod
+    def trainer_send_sparse_weights(
+        iterator: Iterator[Tuple[str, Any]],
+        trainer_args: Dict[str, Any],
+    ) -> None:
+        """Optional trainer-side sparse send."""
+        raise NotImplementedError(
+            "Sparse weight transfer not implemented by this backend"
+        )
+
+    @classmethod
+    def parse_init_info(cls, init_dict: Dict[str, Any]) -> TInitInfo:
+        """Build init_info from a dict.
+
+        Permissive: unknown keys are routed to an `extra` field if present;
+        otherwise dropped silently. The intent is to remain forward-compatible
+        with upstream NCCL/UCX fields without breaking MLX deployments.
+        """
+        fields = {f.name for f in cls.init_info_cls.__dataclass_fields__.values()}
+        known = {k: v for k, v in init_dict.items() if k in fields}
+        unknown = {k: v for k, v in init_dict.items() if k not in fields}
+        if unknown and "extra" in fields:
+            known["extra"] = unknown
+        return cls.init_info_cls(**known)
+
+    @classmethod
+    def parse_update_info(cls, update_dict: Dict[str, Any]) -> TUpdateInfo:
+        """Build update_info from a dict, dropping unknown keys."""
+        fields = {f.name for f in cls.update_info_cls.__dataclass_fields__.values()}
+        return cls.update_info_cls(
+            **{k: v for k, v in update_dict.items() if k in fields}
+        )
+
+
+class WeightTransferEngineFactory:
+    """Lazy backend registry.
+
+    `register_engine` stores `(module_path, class_name)` strings — the first
+    `create_engine(backend, ...)` triggers the import. This honors the
+    constraint that code paths importing mlx MUST be guarded.
+
+    For tests, `register_engine_class` skips the indirection.
+    """
+
+    _registry: Dict[str, Tuple[str, str]] = {}
+    _classes: Dict[str, Type["WeightTransferEngine[Any, Any]"]] = {}
+    _lock = threading.Lock()
+
+    @classmethod
+    def register_engine(cls, backend: str, module_path: str, class_name: str) -> None:
+        """Register a backend by module path + class name (lazy)."""
+        with cls._lock:
+            cls._registry[backend] = (module_path, class_name)
+
+    @classmethod
+    def register_engine_class(
+        cls,
+        backend: str,
+        engine_cls: Type["WeightTransferEngine[Any, Any]"],
+    ) -> None:
+        """Direct (eager) registration — primarily for tests."""
+        with cls._lock:
+            cls._classes[backend] = engine_cls
+
+    @classmethod
+    def get_engine_class(
+        cls, backend: str
+    ) -> Type["WeightTransferEngine[Any, Any]"]:
+        """Resolve the backend class, importing on first access."""
+        with cls._lock:
+            if backend in cls._classes:
+                return cls._classes[backend]
+            if backend not in cls._registry:
+                raise KeyError(
+                    f"No weight-transfer backend registered for: {backend!r}.\n"
+                    f"Registered backends: {list(cls._registry)}\n"
+                    f"See: docs/weight_transfer.md for adding a backend."
+                )
+            module_path, class_name = cls._registry[backend]
+        module = importlib.import_module(module_path)
+        engine_cls = getattr(module, class_name)
+        with cls._lock:
+            cls._classes[backend] = engine_cls
+        return engine_cls
+
+    @classmethod
+    def create_engine(
+        cls,
+        backend: str,
+        config: Any,
+        parallel_config: Any,
+        model: Any,
+    ) -> "WeightTransferEngine[Any, Any]":
+        """Instantiate the backend engine."""
+        engine_cls = cls.get_engine_class(backend)
+        return engine_cls(config, parallel_config, model)
+
+    @classmethod
+    def reset_registry(cls) -> None:
+        """Clear all registrations. Test-only."""
+        with cls._lock:
+            cls._registry.clear()
+            cls._classes.clear()

--- a/vllm_mlx/weight_transfer/mlx_backend.py
+++ b/vllm_mlx/weight_transfer/mlx_backend.py
@@ -1,0 +1,228 @@
+# SPDX-License-Identifier: Apache-2.0
+"""MLX backend for `WeightTransferEngine`.
+
+This module imports `mlx.core` at module top, so it MUST be imported lazily
+(via `WeightTransferEngineFactory.get_engine_class('mlx')`) on Apple-Silicon
+hosts only.
+"""
+
+from __future__ import annotations
+
+import gc
+import logging
+import os
+import tempfile
+from typing import Any, Callable, Dict, Iterator, List, Tuple
+
+import mlx.core as mx
+
+from .base import WeightTransferEngine
+from .types import MLXWeightTransferInitInfo, MLXWeightTransferUpdateInfo
+
+logger = logging.getLogger(__name__)
+
+
+class MLXWeightTransferEngine(
+    WeightTransferEngine[MLXWeightTransferInitInfo, MLXWeightTransferUpdateInfo]
+):
+    """MLX-backed weight transfer engine.
+
+    Honors the upstream `WeightTransferEngine` contract while delegating the
+    actual array materialization to MLX (`mx.load`, `mx.save_safetensors`,
+    `mx.eval`).
+    """
+
+    init_info_cls = MLXWeightTransferInitInfo
+    update_info_cls = MLXWeightTransferUpdateInfo
+
+    def __init__(self, config: Any, parallel_config: Any, model: Any) -> None:
+        super().__init__(config, parallel_config, model)
+        self._initialized = False
+        self._init_info: MLXWeightTransferInitInfo | None = None
+
+    # ------------------------------------------------------------------
+    # Engine lifecycle
+    # ------------------------------------------------------------------
+
+    def init_transfer_engine(
+        self, init_info: MLXWeightTransferInitInfo
+    ) -> None:
+        """Validate single-host invariants and stash session info.
+
+        Args:
+            init_info: Parsed init info. world_size MUST equal 1.
+
+        Raises:
+            ValueError: If world_size != 1 (MLX is single-host only).
+        """
+        if init_info.world_size != 1:
+            raise ValueError(
+                f"MLX weight-transfer backend requires world_size=1, "
+                f"got world_size={init_info.world_size}.\n"
+                f"MLX is single-host (Apple Silicon); use NCCL/UCX for multi-rank.\n"
+                f"See: PROJECT.md scope notes."
+            )
+        if init_info.extra:
+            logger.warning(
+                "MLXWeightTransferEngine: ignoring upstream fields not "
+                "applicable to single-host MLX: %s",
+                sorted(init_info.extra.keys()),
+            )
+        self._init_info = init_info
+        self._initialized = True
+        logger.info(
+            "MLXWeightTransferEngine initialized (rank=%d, backend=%r)",
+            init_info.rank,
+            init_info.backend or "mlx",
+        )
+
+    def shutdown(self) -> None:
+        """Drop references and trigger gc."""
+        self._init_info = None
+        self._initialized = False
+        gc.collect()
+        logger.debug("MLXWeightTransferEngine shutdown complete")
+
+    # ------------------------------------------------------------------
+    # Receive path
+    # ------------------------------------------------------------------
+
+    def receive_weights(
+        self,
+        update_info: MLXWeightTransferUpdateInfo,
+        load_weights: Callable[[List[Tuple[str, Any]]], None],
+    ) -> None:
+        """Materialize one weight update and apply it via `load_weights`.
+
+        Args:
+            update_info: Parsed update info. Exactly one of `path`/`packed`
+                MUST be set.
+            load_weights: Callable invoked once with
+                `[(name, mx.array), ...]` for the parameters in
+                `update_info.names`.
+
+        Raises:
+            ValueError: If neither/both of `path`/`packed` are set, or if
+                lengths/shapes don't match.
+            FileNotFoundError: If `path` is set but the file does not exist.
+        """
+        if not self._initialized:
+            raise RuntimeError(
+                "receive_weights called before init_transfer_engine; "
+                "call init_transfer_engine first."
+            )
+
+        has_path = update_info.path is not None
+        has_packed = update_info.packed is not None
+        if has_path == has_packed:
+            raise ValueError(
+                "MLXWeightTransferUpdateInfo must set exactly one of "
+                "'path' or 'packed'."
+            )
+
+        n = len(update_info.names)
+        if len(update_info.dtype_names) != n or len(update_info.shapes) != n:
+            raise ValueError(
+                f"update_info length mismatch: names={n} "
+                f"dtype_names={len(update_info.dtype_names)} "
+                f"shapes={len(update_info.shapes)}"
+            )
+
+        arrays = self._load_arrays(update_info)
+
+        params_list: List[Tuple[str, Any]] = []
+        for name, expected_shape in zip(update_info.names, update_info.shapes):
+            if name not in arrays:
+                raise KeyError(
+                    f"update_info.names references {name!r} but it was not "
+                    f"found in the loaded safetensors payload."
+                )
+            arr = arrays[name]
+            actual_shape = list(arr.shape)
+            expected = list(expected_shape)
+            if actual_shape != expected:
+                raise ValueError(
+                    f"shape mismatch for {name!r}: "
+                    f"expected {expected}, got {actual_shape}"
+                )
+            params_list.append((name, arr))
+
+        load_weights(params_list)
+
+    def _load_arrays(
+        self, update_info: MLXWeightTransferUpdateInfo
+    ) -> Dict[str, Any]:
+        """Load arrays from `path` or `packed` bytes."""
+        if update_info.path is not None:
+            if not os.path.exists(update_info.path):
+                raise FileNotFoundError(
+                    f"weight-update path does not exist: {update_info.path}"
+                )
+            loaded = mx.load(update_info.path)
+            return self._coerce_to_dict(loaded, update_info.path)
+
+        # packed bytes → tempfile → mx.load
+        assert update_info.packed is not None
+        with tempfile.NamedTemporaryFile(
+            suffix=".safetensors", delete=False
+        ) as tf:
+            tf.write(update_info.packed)
+            tmp_path = tf.name
+        try:
+            loaded = mx.load(tmp_path)
+            return self._coerce_to_dict(loaded, tmp_path)
+        finally:
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
+
+    @staticmethod
+    def _coerce_to_dict(loaded: Any, source: str) -> Dict[str, Any]:
+        """mx.load returns a dict for safetensors; guard against array returns."""
+        if isinstance(loaded, dict):
+            return loaded
+        raise ValueError(
+            f"Expected dict from mx.load({source!r}), got {type(loaded).__name__}. "
+            f"Only safetensors-format payloads are supported."
+        )
+
+    # ------------------------------------------------------------------
+    # Trainer-side helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def trainer_send_weights(
+        iterator: Iterator[Tuple[str, Any]],
+        trainer_args: Dict[str, Any],
+    ) -> None:
+        """Serialize an iterator of (name, mx.array) to safetensors.
+
+        Args:
+            iterator: Yields `(name, mx.array)` pairs.
+            trainer_args: Must include `'out_path'` (str) — destination
+                safetensors file. In-process push (no `out_path`) is not
+                implemented in this MLX-only backend.
+
+        Raises:
+            NotImplementedError: If `out_path` is missing.
+        """
+        out_path = trainer_args.get("out_path")
+        if out_path is None:
+            raise NotImplementedError(
+                "MLXWeightTransferEngine.trainer_send_weights requires "
+                "trainer_args['out_path']; in-process push not implemented."
+            )
+
+        materialized: Dict[str, Any] = {}
+        for name, arr in iterator:
+            # Idempotent barrier — eval() forces any pending lazy ops on arr.
+            mx.eval(arr)
+            materialized[name] = arr
+
+        mx.save_safetensors(out_path, materialized)
+        logger.info(
+            "trainer_send_weights: wrote %d params to %s",
+            len(materialized),
+            out_path,
+        )

--- a/vllm_mlx/weight_transfer/types.py
+++ b/vllm_mlx/weight_transfer/types.py
@@ -1,0 +1,42 @@
+# SPDX-License-Identifier: Apache-2.0
+"""MLX-specific init/update info dataclasses for the weight-transfer engine."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, Optional
+
+from .base import WeightTransferInitInfo, WeightTransferUpdateInfo
+
+
+@dataclass
+class MLXWeightTransferInitInfo(WeightTransferInitInfo):
+    """MLX backend init info.
+
+    Attributes:
+        world_size: MUST be 1 — MLX runs single-host (PROJECT.md scope).
+        rank: Always 0 for MLX.
+        backend: Conventionally "mlx".
+        extra: Forward-compat slot for unknown upstream fields
+            (e.g., NCCL endpoint URIs that we silently ignore).
+    """
+
+    extra: Dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class MLXWeightTransferUpdateInfo(WeightTransferUpdateInfo):
+    """MLX backend update info.
+
+    Exactly one of `path` or `packed` MUST be set. Server-side Pydantic
+    validation enforces this; backend asserts defensively.
+
+    Attributes:
+        path: Filesystem path to a safetensors file (preferred for large updates).
+        packed: Raw packed safetensors bytes (preferred for low-latency in-process).
+        extra: Forward-compat slot for backend-specific fields.
+    """
+
+    path: Optional[str] = None
+    packed: Optional[bytes] = None
+    extra: Dict[str, Any] = field(default_factory=dict)


### PR DESCRIPTION
## Summary

Implements vLLM's documented `WeightTransferEngine` extension interface for the MLX backend so a colocated GRPO trainer can hot-reload model weights without restarting the server. Apple Silicon's unified memory means no NCCL broadcast — the trainer `mx.eval()`s its updated params, the server rebinds via `model.update(params_dict)`, the scheduler pauses + KV/prefix caches are invalidated, then everything resumes against new weights.

**Plan-1.5 Patch #3 of 3.** Unblocks `realign train --backend grpo_vllm --reload-every 1` against a colocated MLX server. Tracks [akaszubski/realign#1309](https://github.com/akaszubski/realign/issues/1309); parent realign#1307.

## What's new

**7 root-level HTTP routes** mirroring upstream `vllm-project/vllm` async-RL surface (all auth-gated):
- `POST /init_weight_transfer_engine` · `POST /start_weight_update` · `POST /update_weights` · `POST /finish_weight_update`
- `POST /pause` (`mode` ∈ `{abort, wait, keep}`) · `POST /resume` · `GET /get_world_size`

**Scheduler** gains `pause(mode, clear_cache, timeout_s)` / `resume()` with `step()` short-circuit when paused. `_drain_inflight(timeout_s)` polls `self.running` until empty or timeout.

**Engine-core shims** (9 new methods) bridge HTTP → scheduler + cache + `model.update`. `_load_weights` closure emits an INFO audit log then calls `model.update(params_dict)` + `mx.eval(model.parameters())` as the materialization barrier.

**WeightTransferEngineFactory** uses lazy string-based registration (`register_engine('mlx', module_path, class_name)`) — `mlx` is never imported by `import vllm_mlx` on non-Apple-Silicon hosts. Verified: ``python3.14 -c "import sys, vllm_mlx; print('mlx' in sys.modules)"`` → `False`.

**Pydantic models** (`vllm_mlx/api/models.py`): `WeightTransferInitRequest`, `StartWeightUpdateRequest`, `WeightTransferUpdateRequest` (with `@model_validator` enforcing exactly-one-of `packed | path`), `PauseRequest`.

## Test plan

- [x] `python3.14 -m pytest tests/test_weight_transfer_mlx.py -v` → **38 passed, 1 skipped** (intentional integration test, OUT OF SCOPE per PROJECT.md)
- [x] All 9 acceptance criteria covered 1-to-1:
  - AC-1 factory lazy registration (`mlx` not imported by `import vllm_mlx`)
  - AC-2 `pause(wait|abort|keep)` + `resume()` + `step()` gate (5 sub-tests)
  - AC-3 `clear_kv_and_prefix_cache` delegates to existing scheduler hooks
  - AC-4 10-cycle pause/update/resume no memory growth (16 MiB epsilon, real `mlx.nn.Linear`)
  - AC-5 pre-compiled `mx.compile()` kernel survives `model.update()`
  - AC-6 `trainer_send_weights` calls `mx.eval()` as documented contract
  - AC-7 all 7 routes return 401 without auth, dispatch correctly with auth (8 sub-tests)
  - AC-8 Pydantic 422 on malformed bodies (7 sub-tests covering missing keys, length mismatch, both/neither packed-path, bad pause mode)
  - AC-9 CHANGELOG `[Unreleased] / Added` entry
- [x] Independent regression spot-check: `tests/test_api_models.py` (79 passed), `tests/test_batching.py` (21 passed + 5 pre-existing event-loop teardown errors — stash-confirmed identical without this patch's changes)
- [x] Import-chain check: `from vllm_mlx.weight_transfer import WeightTransferEngineFactory; cls = WeightTransferEngineFactory.get_engine_class('mlx')` → lazy loads, returns `MLXWeightTransferEngine` subclass of `WeightTransferEngine`
- [ ] **OUT OF SCOPE per PROJECT.md** (deferred to realign#1309 follow-up): trainer-level e2e (`realign train --backend grpo_vllm --iters 5 --reload-every 1`), LoRA + grad-step + async_eval deadlock check

## Security audit

**Verdict: PASS** (0 CRITICAL/HIGH). In-PR remediations:
- **M-3** (MEDIUM): `/update_weights` now requires prior `/start_weight_update` — re-entrancy guard prevents racing `model.update()` with active inference.
- **L-1** (LOW): audit-log INFO line emitted before each `model.update()` (forensic trail for the highest-risk operation).

**Filed as follow-up issues** (out of scope for this PR; surface as multi-trainer support lands):
- **M-1** (MEDIUM): `/init_weight_transfer_engine` has no ownership token — a second authenticated caller can replace the engine mid-cycle. Single-trainer deployments unaffected.
- **M-2** (MEDIUM): `update_info.path` accepts arbitrary local paths the server can read. Restrict via `--weight-transfer-root` flag with `os.path.realpath` + `is_relative_to()` guard.
- **L-2** (LOW): `dtype_names` structurally validated but not compared against actual array dtypes after `mx.load`.
- **L-3** (LOW): tempfile unlink failure in `_load_arrays` silently swallowed — add `logger.warning`.

## Docs

- `README.md`: new bullet under "Reasoning & advanced" listing the RLHF weight hot-reload surface.
- `docs/guides/server.md`: new "Weight Transfer / RLHF Routes" section with route table, pause-mode table, and a 3-step curl example covering the full update cycle.
- `CHANGELOG.md` (created on this branch — `main` doesn't have it; patch #1's CHANGELOG is on a separate branch and will be resolved at rebase): `[Unreleased] / Added` entries with `(realign#1309)` issue refs.
- Localized READMEs (`README.es.md`, `README.fr.md`, `README.zh.md`) flagged for translation pass (matches patch #1 convention).

## Risk register status (from spec)

| Risk | Mitigation in code |
|------|-------------------|
| MLX `set_parameter` requires re-tracing | Use `model.update(params_dict)` instead — `mx.compile()`-cached kernels are keyed on shape/dtype, survive rebind (test_precompiled_kernel_survives_update verifies). |
| Paused scheduler has tokens in-flight | `pause(mode='wait', timeout_s=30)` calls `_drain_inflight` polling loop; on timeout, transitions to paused anyway and logs warning. |
| KV cache invalidation cascades to prefix-cache | `engine.clear_kv_and_prefix_cache` calls BOTH `scheduler.clear_runtime_caches()` AND `scheduler.clear_prefix_cache()` (hasattr-guarded). |
| MLX unified memory lazy-eval | `trainer_send_weights` explicitly calls `mx.eval(arr)` on each tensor; documented contract in docstring. |

## Upstream contribution path

The `MLXWeightTransferEngine` subclasses a locally-defined `WeightTransferEngine` ABC (since `vllm` pip package is not installed in vllm-mlx). The class shape, method signatures, and HTTP route paths exactly mirror upstream v0.23+ — see `vllm_mlx/weight_transfer/base.py` docstring. Tracked under [realign#1310](https://github.com/akaszubski/realign/issues/1310) for the upstream contribution PR.

## Not in this PR

- The `asyncio.gather` → `asyncio.TaskGroup` migration from realign#1311 / A04-4 (the 7 new routes are simple `async def` with single awaits — no new `gather` sites introduced by this patch).

## Stats

- 12 files changed: 6 new, 6 modified
- +1815 / -2 lines
- 38 new test cases (1 skipped intentional integration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)