### PR TITLE
feat(api): SamplingParams.n group sampling on /v1/chat/completions and /v1/completions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- `SamplingParams.n` group sampling (1..64) and `best_of` field for `/v1/chat/completions` and `/v1/completions`. Enables GRPO/RLHF rollout group sampling against a single colocated MLX server. Streaming (`stream=True`) with `n>1` rejected with HTTP 400 (OpenAI-compatible error envelope). Prefix cache automatically dedups the shared prompt-KV across rollouts. Anthropic `/v1/messages` is unaffected (native Anthropic API does not expose `n`). E2E model-load integration tests deferred to a follow-up patch. (realign#1308 / Plan-1.5 patch #1)
 - MLX-backend `WeightTransferEngine` for RLHF/GRPO weight hot-reload.
   Registers via `WeightTransferEngineFactory.register_engine('mlx', ...)`
   with lazy import so non-Apple-Silicon installs are unaffected. (realign#1307, realign#1309)

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ claude
 - **Speculative decoding**: `--mtp` for Qwen3-Next
 - **Sparse prefill**: attention-based `--spec-prefill` for TTFT reduction
 - **RLHF/GRPO weight hot-reload**: 7 trainer-facing HTTP routes (`/init_weight_transfer_engine`, `/update_weights`, `/pause`, `/resume`, etc.) mirror upstream vLLM async-RL surface for colocated training
+- **Group sampling** (`n`): generate up to 64 independent completions per prompt for GRPO/RLHF rollout collection; prefix cache deduplicates the shared prompt-KV automatically
 
 ### Observability
 - **Prometheus metrics**: `/metrics` endpoint with `--metrics`

--- a/docs/guides/server.md
+++ b/docs/guides/server.md
@@ -98,6 +98,26 @@ for chunk in stream:
         print(chunk.choices[0].delta.content, end="")
 ```
 
+#### Group sampling (`n`)
+
+Request multiple independent completions for the same prompt in a single API call. Useful for GRPO/RLHF rollout collection against a single colocated MLX server.
+
+```python
+# Generate 4 independent completions for the same prompt
+response = client.chat.completions.create(
+    model="default",
+    messages=[{"role": "user", "content": "Write a haiku about the ocean."}],
+    n=4,
+    max_tokens=60,
+)
+for i, choice in enumerate(response.choices):
+    print(f"[{i}] {choice.message.content}")
+```
+
+`n` accepts integers from 1 to 64 (default: 1). The prompt-KV is computed once and shared across all rollouts via prefix cache. Token usage follows OpenAI semantics: `prompt_tokens` is counted once; `completion_tokens` is the sum across all `n` choices.
+
+**Constraint**: `n > 1` with `stream=True` returns HTTP 400 (`stream_n_unsupported`). Use non-streaming requests when `n > 1`.
+
 ### Completions
 
 ```bash
@@ -110,6 +130,16 @@ response = client.completions.create(
     prompt="The capital of France is",
     max_tokens=50
 )
+
+# Group sampling: generate n independent completions per prompt
+response = client.completions.create(
+    model="default",
+    prompt="The capital of France is",
+    n=4,
+    max_tokens=50,
+)
+for choice in response.choices:
+    print(choice.text)
 ```
 
 ### Models

--- a/tests/test_api_models.py
+++ b/tests/test_api_models.py
@@ -724,3 +724,288 @@ class TestModelSerialization:
         )
         data = schema.model_dump(by_alias=True)
         assert "schema" in data
+
+
+# =============================================================================
+# Group sampling (SamplingParams.n) — Plan-1.5 Patch #1
+# =============================================================================
+
+import platform
+import sys
+from collections import OrderedDict
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from pydantic import ValidationError
+
+# Server-dependent tests need Apple Silicon (the server module imports MLX).
+_requires_arm_darwin = pytest.mark.skipif(
+    sys.platform != "darwin" or platform.machine() != "arm64",
+    reason="Server import requires Apple Silicon (MLX)",
+)
+
+
+def _gs_make_output(
+    text: str = "ok",
+    prompt_tokens: int = 10,
+    completion_tokens: int = 3,
+    finish_reason: str = "stop",
+) -> SimpleNamespace:
+    """Build a SimpleNamespace mirroring engine.generate/chat return shape."""
+    return SimpleNamespace(
+        text=text,
+        prompt_tokens=prompt_tokens,
+        completion_tokens=completion_tokens,
+        finish_reason=finish_reason,
+    )
+
+
+def _gs_mock_engine(*outputs: SimpleNamespace) -> MagicMock:
+    """Mock engine whose .chat and .generate return the supplied outputs in order."""
+    engine = MagicMock()
+    engine.model_name = "test-model"
+    engine.preserve_native_tool_format = False
+    engine.is_mllm = False
+    engine.tokenizer = None
+    engine._tokenizer = None
+    output_list = list(outputs)
+    engine.chat = AsyncMock(side_effect=output_list)
+    engine.generate = AsyncMock(side_effect=output_list)
+    return engine
+
+
+@pytest.fixture()
+def _gs_client():
+    from fastapi.testclient import TestClient
+
+    from vllm_mlx.server import app
+
+    return TestClient(app)
+
+
+@pytest.fixture()
+def _gs_server_state():
+    """Snapshot and restore module-level server state for isolation."""
+    import vllm_mlx.server as srv
+
+    original_engine = srv._engine
+    original_model_name = srv._model_name
+    original_api_key = srv._api_key
+    original_default_chat_template_kwargs = getattr(
+        srv, "_default_chat_template_kwargs", None
+    )
+    original_residency_manager = srv._residency_manager
+    original_default_model_key = srv._default_model_key
+    original_responses_store = srv._responses_store
+    original_responses_store_max = srv._RESPONSES_STORE_MAX_SIZE
+
+    srv._engine = None
+    srv._model_name = "test-model"
+    srv._api_key = None
+    srv._default_chat_template_kwargs = None
+    srv._residency_manager = None
+    srv._default_model_key = None
+    srv._responses_store = OrderedDict()
+    srv._RESPONSES_STORE_MAX_SIZE = 1000
+
+    try:
+        yield srv
+    finally:
+        srv._engine = original_engine
+        srv._model_name = original_model_name
+        srv._api_key = original_api_key
+        srv._default_chat_template_kwargs = original_default_chat_template_kwargs
+        srv._residency_manager = original_residency_manager
+        srv._default_model_key = original_default_model_key
+        srv._responses_store = original_responses_store
+        srv._RESPONSES_STORE_MAX_SIZE = original_responses_store_max
+
+
+class TestGroupSampling:
+    """Tests for SamplingParams.n group sampling — AC1-AC8."""
+
+    # ---- AC1-AC5: Pydantic validation (no server import) ----
+
+    def test_chat_n_defaults_to_one(self):
+        req = ChatCompletionRequest(
+            model="test-model",
+            messages=[Message(role="user", content="hi")],
+        )
+        assert req.n == 1
+        assert req.best_of is None
+
+    def test_completion_n_defaults_to_one(self):
+        req = CompletionRequest(model="test-model", prompt="hi")
+        assert req.n == 1
+        assert req.best_of is None
+
+    def test_chat_n_accepts_group_sampling(self):
+        req = ChatCompletionRequest(
+            model="test-model",
+            messages=[Message(role="user", content="hi")],
+            n=4,
+        )
+        assert req.n == 4
+
+    def test_completion_n_accepts_group_sampling(self):
+        req = CompletionRequest(model="test-model", prompt="hi", n=4)
+        assert req.n == 4
+
+    def test_chat_n_zero_rejected(self):
+        with pytest.raises(ValidationError):
+            ChatCompletionRequest(
+                model="test-model",
+                messages=[Message(role="user", content="hi")],
+                n=0,
+            )
+
+    def test_completion_n_zero_rejected(self):
+        with pytest.raises(ValidationError):
+            CompletionRequest(model="test-model", prompt="hi", n=0)
+
+    def test_chat_n_above_64_rejected(self):
+        with pytest.raises(ValidationError):
+            ChatCompletionRequest(
+                model="test-model",
+                messages=[Message(role="user", content="hi")],
+                n=65,
+            )
+
+    def test_completion_n_above_64_rejected(self):
+        with pytest.raises(ValidationError):
+            CompletionRequest(model="test-model", prompt="hi", n=65)
+
+    # ---- AC6: stream + n>1 → HTTP 400 with code=stream_n_unsupported ----
+
+    @_requires_arm_darwin
+    def test_chat_stream_with_n_gt_1_returns_400(
+        self, _gs_client, _gs_server_state
+    ):
+        resp = _gs_client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "test-model",
+                "messages": [{"role": "user", "content": "hi"}],
+                "stream": True,
+                "n": 2,
+            },
+        )
+        assert resp.status_code == 400, resp.text
+        body = resp.json()
+        assert body["error"]["code"] == "stream_n_unsupported"
+        assert body["error"]["type"] == "invalid_request_error"
+        assert body["error"]["param"] == "stream"
+
+    @_requires_arm_darwin
+    def test_completion_stream_with_n_gt_1_returns_400(
+        self, _gs_client, _gs_server_state
+    ):
+        resp = _gs_client.post(
+            "/v1/completions",
+            json={
+                "model": "test-model",
+                "prompt": "hi",
+                "stream": True,
+                "n": 2,
+            },
+        )
+        assert resp.status_code == 400, resp.text
+        body = resp.json()
+        assert body["error"]["code"] == "stream_n_unsupported"
+        assert body["error"]["type"] == "invalid_request_error"
+        assert body["error"]["param"] == "stream"
+
+    # ---- AC7: n=4 returns 4 choices with distinct indices 0..3 ----
+
+    @_requires_arm_darwin
+    def test_chat_n_4_returns_4_choices_with_distinct_indices(
+        self, _gs_client, _gs_server_state
+    ):
+        _gs_server_state._engine = _gs_mock_engine(
+            _gs_make_output("rollout-0"),
+            _gs_make_output("rollout-1"),
+            _gs_make_output("rollout-2"),
+            _gs_make_output("rollout-3"),
+        )
+        resp = _gs_client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "test-model",
+                "messages": [{"role": "user", "content": "hi"}],
+                "n": 4,
+            },
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert len(body["choices"]) == 4
+        assert [c["index"] for c in body["choices"]] == [0, 1, 2, 3]
+        texts = [c["message"]["content"] for c in body["choices"]]
+        assert texts == ["rollout-0", "rollout-1", "rollout-2", "rollout-3"]
+
+    @_requires_arm_darwin
+    def test_completion_n_4_returns_4_choices_with_distinct_indices(
+        self, _gs_client, _gs_server_state
+    ):
+        _gs_server_state._engine = _gs_mock_engine(
+            _gs_make_output("rollout-0"),
+            _gs_make_output("rollout-1"),
+            _gs_make_output("rollout-2"),
+            _gs_make_output("rollout-3"),
+        )
+        resp = _gs_client.post(
+            "/v1/completions",
+            json={"model": "test-model", "prompt": "hi", "n": 4},
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert len(body["choices"]) == 4
+        assert [c["index"] for c in body["choices"]] == [0, 1, 2, 3]
+        texts = [c["text"] for c in body["choices"]]
+        assert texts == ["rollout-0", "rollout-1", "rollout-2", "rollout-3"]
+
+    # ---- AC8: token accounting — prompt counted once, completions summed ----
+
+    @_requires_arm_darwin
+    def test_chat_n_4_token_accounting(self, _gs_client, _gs_server_state):
+        _gs_server_state._engine = _gs_mock_engine(
+            _gs_make_output("a", prompt_tokens=10, completion_tokens=3),
+            _gs_make_output("b", prompt_tokens=10, completion_tokens=3),
+            _gs_make_output("c", prompt_tokens=10, completion_tokens=3),
+            _gs_make_output("d", prompt_tokens=10, completion_tokens=3),
+        )
+        resp = _gs_client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "test-model",
+                "messages": [{"role": "user", "content": "hi"}],
+                "n": 4,
+            },
+        )
+        assert resp.status_code == 200, resp.text
+        usage = resp.json()["usage"]
+        # Prompt tokens counted ONCE (NOT 40), completions summed (3 * 4 = 12).
+        assert usage["prompt_tokens"] == 10
+        assert usage["completion_tokens"] == 12
+        assert usage["total_tokens"] == 22
+
+    @_requires_arm_darwin
+    def test_completion_n_4_token_accounting(
+        self, _gs_client, _gs_server_state
+    ):
+        _gs_server_state._engine = _gs_mock_engine(
+            _gs_make_output("a", prompt_tokens=10, completion_tokens=3),
+            _gs_make_output("b", prompt_tokens=10, completion_tokens=3),
+            _gs_make_output("c", prompt_tokens=10, completion_tokens=3),
+            _gs_make_output("d", prompt_tokens=10, completion_tokens=3),
+        )
+        resp = _gs_client.post(
+            "/v1/completions",
+            json={"model": "test-model", "prompt": "hi", "n": 4},
+        )
+        assert resp.status_code == 200, resp.text
+        usage = resp.json()["usage"]
+        # Prompt tokens counted ONCE per prompt (NOT 40), completions summed.
+        assert usage["prompt_tokens"] == 10
+        assert usage["completion_tokens"] == 12
+        assert usage["total_tokens"] == 22

--- a/tests/test_spec_validator_n_param.py
+++ b/tests/test_spec_validator_n_param.py
@@ -1,0 +1,328 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Spec-validator tests for SamplingParams.n (group sampling).
+
+These tests are written BLIND to the implementation: they encode the
+acceptance criteria from the feature spec only. They MUST pass against any
+correct implementation, and MUST fail against a non-compliant one.
+"""
+
+from __future__ import annotations
+
+import platform
+import sys
+from collections import OrderedDict
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi.testclient import TestClient
+from pydantic import ValidationError
+
+from vllm_mlx.api.models import (
+    ChatCompletionRequest,
+    CompletionRequest,
+)
+
+# Server import (for AC6/AC7/AC8) is Apple-Silicon-only.
+_IS_APPLE_SILICON = sys.platform == "darwin" and platform.machine() == "arm64"
+
+
+# ---------------------------------------------------------------------------
+# Schema-level tests (AC1..AC5, AC12 partial) — no server required
+# ---------------------------------------------------------------------------
+
+
+def _chat_kwargs(**extra):
+    return dict(
+        model="m",
+        messages=[{"role": "user", "content": "hi"}],
+        **extra,
+    )
+
+
+def _completion_kwargs(**extra):
+    return dict(model="m", prompt="hi", **extra)
+
+
+# --- AC1 ---
+def test_ac1_chat_default_n_is_1_and_best_of_none():
+    req = ChatCompletionRequest(**_chat_kwargs())
+    assert req.n == 1
+    assert req.best_of is None
+
+
+# --- AC2 ---
+def test_ac2_chat_accepts_n_4():
+    req = ChatCompletionRequest(**_chat_kwargs(n=4))
+    assert req.n == 4
+
+
+# --- AC3 ---
+def test_ac3_chat_rejects_n_0():
+    with pytest.raises(ValidationError):
+        ChatCompletionRequest(**_chat_kwargs(n=0))
+
+
+# --- AC4 ---
+def test_ac4_chat_rejects_n_65():
+    with pytest.raises(ValidationError):
+        ChatCompletionRequest(**_chat_kwargs(n=65))
+
+
+# --- AC5 (mirrored for CompletionRequest) ---
+def test_ac5_completion_default_n_is_1_and_best_of_none():
+    req = CompletionRequest(**_completion_kwargs())
+    assert req.n == 1
+    assert req.best_of is None
+
+
+def test_ac5_completion_accepts_n_4():
+    req = CompletionRequest(**_completion_kwargs(n=4))
+    assert req.n == 4
+
+
+def test_ac5_completion_rejects_n_0():
+    with pytest.raises(ValidationError):
+        CompletionRequest(**_completion_kwargs(n=0))
+
+
+def test_ac5_completion_rejects_n_65():
+    with pytest.raises(ValidationError):
+        CompletionRequest(**_completion_kwargs(n=65))
+
+
+# --- AC12: best_of bounds and no `seed` field added ---
+def test_ac12_chat_best_of_bounds():
+    # best_of accepts None (default), 1, 64; rejects 0 and 65.
+    assert ChatCompletionRequest(**_chat_kwargs(best_of=1)).best_of == 1
+    assert ChatCompletionRequest(**_chat_kwargs(best_of=64)).best_of == 64
+    with pytest.raises(ValidationError):
+        ChatCompletionRequest(**_chat_kwargs(best_of=0))
+    with pytest.raises(ValidationError):
+        ChatCompletionRequest(**_chat_kwargs(best_of=65))
+
+
+def test_ac12_completion_best_of_bounds():
+    assert CompletionRequest(**_completion_kwargs(best_of=1)).best_of == 1
+    assert CompletionRequest(**_completion_kwargs(best_of=64)).best_of == 64
+    with pytest.raises(ValidationError):
+        CompletionRequest(**_completion_kwargs(best_of=0))
+    with pytest.raises(ValidationError):
+        CompletionRequest(**_completion_kwargs(best_of=65))
+
+
+def test_ac12_no_seed_field_added():
+    """Spec says no `seed` field added by this patch."""
+    chat_fields = set(ChatCompletionRequest.model_fields.keys())
+    comp_fields = set(CompletionRequest.model_fields.keys())
+    assert "seed" not in chat_fields, "spec forbids new `seed` field on ChatCompletionRequest"
+    assert "seed" not in comp_fields, "spec forbids new `seed` field on CompletionRequest"
+
+
+def test_ac12_n_field_type_and_default():
+    chat_field = ChatCompletionRequest.model_fields["n"]
+    comp_field = CompletionRequest.model_fields["n"]
+    assert chat_field.default == 1
+    assert comp_field.default == 1
+    # Type annotation should be int (not Optional[int]).
+    assert chat_field.annotation is int
+    assert comp_field.annotation is int
+
+
+# ---------------------------------------------------------------------------
+# Handler-level tests (AC6, AC7, AC8) — require server import
+# ---------------------------------------------------------------------------
+
+pytestmark_server = pytest.mark.skipif(
+    not _IS_APPLE_SILICON,
+    reason="Server import requires Apple Silicon (MLX dependency)",
+)
+
+
+@pytest.fixture()
+def client():
+    from vllm_mlx.server import app
+
+    return TestClient(app)
+
+
+@pytest.fixture(autouse=True)
+def server_state():
+    """Reset module-level server state between tests."""
+    if not _IS_APPLE_SILICON:
+        yield
+        return
+    import vllm_mlx.server as srv
+
+    saved = {
+        "engine": srv._engine,
+        "model_name": srv._model_name,
+        "store": srv._responses_store,
+        "store_max": srv._RESPONSES_STORE_MAX_SIZE,
+        "api_key": srv._api_key,
+        "default_ctk": getattr(srv, "_default_chat_template_kwargs", None),
+    }
+    srv._engine = None
+    srv._model_name = "test-model"
+    srv._responses_store = OrderedDict()
+    srv._RESPONSES_STORE_MAX_SIZE = 1000
+    srv._api_key = None
+    srv._default_chat_template_kwargs = None
+    try:
+        yield
+    finally:
+        srv._engine = saved["engine"]
+        srv._model_name = saved["model_name"]
+        srv._responses_store = saved["store"]
+        srv._RESPONSES_STORE_MAX_SIZE = saved["store_max"]
+        srv._api_key = saved["api_key"]
+        srv._default_chat_template_kwargs = saved["default_ctk"]
+
+
+def _make_chat_output(text: str, prompt_tokens: int = 7, completion_tokens: int = 3):
+    return SimpleNamespace(
+        text=text,
+        prompt_tokens=prompt_tokens,
+        completion_tokens=completion_tokens,
+        finish_reason="stop",
+    )
+
+
+def _make_completion_output(text: str, prompt_tokens: int = 7, completion_tokens: int = 3):
+    return SimpleNamespace(
+        text=text,
+        prompt_tokens=prompt_tokens,
+        completion_tokens=completion_tokens,
+        finish_reason="stop",
+    )
+
+
+def _install_mock_chat_engine(monkeypatch, outputs):
+    """Install a mocked engine for chat completions with the given outputs."""
+    import vllm_mlx.server as srv
+
+    engine = MagicMock()
+    engine.model_name = "test-model"
+    engine.preserve_native_tool_format = False
+    engine.chat = AsyncMock(side_effect=list(outputs))
+    srv._engine = engine
+
+    async def _acquire(*args, **kwargs):
+        return engine
+
+    async def _release(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr(srv, "_acquire_default_engine_for_request", _acquire)
+    monkeypatch.setattr(srv, "_release_default_engine", _release)
+    return engine
+
+
+def _install_mock_completion_engine(monkeypatch, outputs):
+    import vllm_mlx.server as srv
+
+    engine = MagicMock()
+    engine.model_name = "test-model"
+    engine.generate = AsyncMock(side_effect=list(outputs))
+    srv._engine = engine
+
+    async def _acquire(*args, **kwargs):
+        return engine
+
+    async def _release(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr(srv, "_acquire_default_engine_for_request", _acquire)
+    monkeypatch.setattr(srv, "_release_default_engine", _release)
+    return engine
+
+
+# --- AC6: streaming + n>1 -> HTTP 400 with stream_n_unsupported code ---
+@pytestmark_server
+def test_ac6_chat_stream_with_n_gt_1_returns_400(client):
+    body = {
+        "model": "test-model",
+        "messages": [{"role": "user", "content": "hi"}],
+        "n": 4,
+        "stream": True,
+    }
+    resp = client.post("/v1/chat/completions", json=body)
+    assert resp.status_code == 400, resp.text
+    data = resp.json()
+    assert "error" in data, data
+    assert data["error"].get("code") == "stream_n_unsupported", data
+
+
+@pytestmark_server
+def test_ac6_completion_stream_with_n_gt_1_returns_400(client):
+    body = {
+        "model": "test-model",
+        "prompt": "hi",
+        "n": 4,
+        "stream": True,
+    }
+    resp = client.post("/v1/completions", json=body)
+    assert resp.status_code == 400, resp.text
+    data = resp.json()
+    assert "error" in data, data
+    assert data["error"].get("code") == "stream_n_unsupported", data
+
+
+# --- AC7 + AC8: n=4 non-stream returns 4 choices with distinct indices,
+# and usage counts prompt_tokens once but completion_tokens summed.
+@pytestmark_server
+def test_ac7_ac8_chat_n_4_non_stream(client, monkeypatch):
+    PT = 11  # prompt_tokens reported by mock engine
+    CT_PER = 5  # completion_tokens per rollout
+    outputs = [_make_chat_output(f"reply-{i}", PT, CT_PER) for i in range(4)]
+    _install_mock_chat_engine(monkeypatch, outputs)
+
+    body = {
+        "model": "test-model",
+        "messages": [{"role": "user", "content": "hi"}],
+        "n": 4,
+        "stream": False,
+        "max_tokens": 8,
+    }
+    resp = client.post("/v1/chat/completions", json=body)
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+
+    # AC7: 4 choices with distinct indices 0..3
+    assert len(data["choices"]) == 4, data
+    indices = sorted(c["index"] for c in data["choices"])
+    assert indices == [0, 1, 2, 3], indices
+
+    # AC8: prompt_tokens counted ONCE; completion_tokens summed; total consistent.
+    usage = data["usage"]
+    assert usage["prompt_tokens"] == PT, usage
+    assert usage["completion_tokens"] == CT_PER * 4, usage
+    assert usage["total_tokens"] == usage["prompt_tokens"] + usage["completion_tokens"]
+
+
+@pytestmark_server
+def test_ac7_ac8_completion_n_4_non_stream(client, monkeypatch):
+    PT = 9
+    CT_PER = 4
+    outputs = [_make_completion_output(f"text-{i}", PT, CT_PER) for i in range(4)]
+    _install_mock_completion_engine(monkeypatch, outputs)
+
+    body = {
+        "model": "test-model",
+        "prompt": "hi",
+        "n": 4,
+        "stream": False,
+        "max_tokens": 8,
+    }
+    resp = client.post("/v1/completions", json=body)
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+
+    assert len(data["choices"]) == 4, data
+    indices = sorted(c["index"] for c in data["choices"])
+    assert indices == [0, 1, 2, 3], indices
+
+    usage = data["usage"]
+    assert usage["prompt_tokens"] == PT, usage
+    assert usage["completion_tokens"] == CT_PER * 4, usage
+    assert usage["total_tokens"] == usage["prompt_tokens"] + usage["completion_tokens"]

--- a/vllm_mlx/api/models.py
+++ b/vllm_mlx/api/models.py
@@ -195,6 +195,13 @@ class ChatCompletionRequest(BaseModel):
     specprefill_keep_pct: float | None = None
     # Enable/disable thinking mode (None = server default, typically True)
     enable_thinking: bool | None = None
+    # Group sampling: number of completions to generate per prompt (1..64).
+    # n=1 preserves existing behaviour bit-identically; n>1 fans out N parallel
+    # rollouts (used for GRPO/RLHF). Streaming with n>1 is rejected with HTTP 400.
+    n: int = Field(default=1, ge=1, le=64)
+    # best_of: validated for OpenAI/vLLM API parity; selection logic not
+    # yet implemented in the MLX engine (tracked separately).
+    best_of: int | None = Field(default=None, ge=1, le=64)
 
 
 class AssistantMessage(BaseModel):
@@ -281,6 +288,14 @@ class CompletionRequest(BaseModel):
     specprefill: bool | None = None
     # SpecPrefill: per-request keep percentage (0.0-1.0, None = use server default)
     specprefill_keep_pct: float | None = None
+    # Group sampling: number of completions to generate per prompt (1..64).
+    # n=1 preserves existing behaviour bit-identically; n>1 fans out N parallel
+    # rollouts per prompt (used for GRPO/RLHF). Streaming with n>1 is rejected
+    # with HTTP 400.
+    n: int = Field(default=1, ge=1, le=64)
+    # best_of: validated for OpenAI/vLLM API parity; selection logic not
+    # yet implemented in the MLX engine (tracked separately).
+    best_of: int | None = Field(default=None, ge=1, le=64)
 
 
 class CompletionChoice(BaseModel):

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -56,7 +56,7 @@ from contextlib import suppress
 
 import uvicorn
 from fastapi import Depends, FastAPI, HTTPException, Request, UploadFile
-from fastapi.responses import Response, StreamingResponse
+from fastapi.responses import JSONResponse, Response, StreamingResponse
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from pydantic import BaseModel
 from starlette.routing import Match
@@ -3871,6 +3871,18 @@ async def _acquire_default_engine_for_request(
 async def create_completion(request: CompletionRequest, raw_request: Request):
     """Create a text completion."""
     _validate_model_name(request.model)
+    if request.stream and request.n > 1:
+        return JSONResponse(
+            status_code=400,
+            content={
+                "error": {
+                    "message": "stream=true is not supported when n>1",
+                    "type": "invalid_request_error",
+                    "code": "stream_n_unsupported",
+                    "param": "stream",
+                }
+            },
+        )
     effective_max_tokens = _resolve_request_max_tokens(request.max_tokens)
     tracker = _metrics.track_inference("completions", stream=request.stream)
 
@@ -3948,6 +3960,58 @@ async def create_completion(request: CompletionRequest, raw_request: Request):
                 generate_kwargs["specprefill"] = request.specprefill
             if request.specprefill_keep_pct is not None:
                 generate_kwargs["specprefill_keep_pct"] = request.specprefill_keep_pct
+            if request.n > 1:
+                # Group sampling: fan out N parallel rollouts for this prompt.
+                # Prompt tokens are counted once per prompt (shared prefix KV);
+                # completion tokens are summed across all rollouts.
+                try:
+                    gather_coro = asyncio.gather(
+                        *(
+                            engine.generate(**generate_kwargs)
+                            for _ in range(request.n)
+                        )
+                    )
+                    if raw_request is None:
+                        outputs = await gather_coro
+                    else:
+                        outputs = await _wait_with_disconnect(
+                            gather_coro,
+                            raw_request,
+                            timeout=_remaining_request_timeout(
+                                total_timeout, deadline
+                            ),
+                            timeout_detail_seconds=total_timeout,
+                        )
+                except HTTPException as exc:
+                    tracker.finish(
+                        result=_metrics_result_from_status(exc.status_code)
+                    )
+                    raise
+                if outputs is None:
+                    tracker.finish(
+                        result="client_closed",
+                        prompt_tokens=total_prompt_tokens,
+                        completion_tokens=total_completion_tokens,
+                    )
+                    return Response(status_code=499)  # Client closed request
+
+                for k, output in enumerate(outputs):
+                    choices.append(
+                        CompletionChoice(
+                            index=i * request.n + k,
+                            text=output.text,
+                            finish_reason=output.finish_reason,
+                        )
+                    )
+                    total_completion_tokens += output.completion_tokens
+                # Count prompt tokens ONCE per prompt (not per rollout).
+                total_prompt_tokens += (
+                    outputs[0].prompt_tokens
+                    if hasattr(outputs[0], "prompt_tokens")
+                    else 0
+                )
+                continue
+
             try:
                 if raw_request is None:
                     output = await engine.generate(**generate_kwargs)
@@ -4053,6 +4117,18 @@ async def create_chat_completion(request: ChatCompletionRequest, raw_request: Re
     ```
     """
     _validate_model_name(request.model)
+    if request.stream and request.n > 1:
+        return JSONResponse(
+            status_code=400,
+            content={
+                "error": {
+                    "message": "stream=true is not supported when n>1",
+                    "type": "invalid_request_error",
+                    "code": "stream_n_unsupported",
+                    "param": "stream",
+                }
+            },
+        )
     effective_max_tokens = _resolve_request_max_tokens(request.max_tokens)
     tracker = _metrics.track_inference("chat_completions", stream=request.stream)
     total_timeout, deadline = _start_request_budget(request.timeout)
@@ -4122,6 +4198,106 @@ async def create_chat_completion(request: ChatCompletionRequest, raw_request: Re
             return response
 
         start_time = time.perf_counter()
+
+        if request.n > 1:
+            # Group sampling: fan out N parallel chat rollouts.
+            # Prompt tokens are counted once (shared prefix KV across rollouts);
+            # completion tokens are summed across all rollouts.
+            try:
+                gather_coro = asyncio.gather(
+                    *(
+                        engine.chat(
+                            messages=prepared.messages, **prepared.chat_kwargs
+                        )
+                        for _ in range(request.n)
+                    )
+                )
+                outputs = await _wait_with_disconnect(
+                    gather_coro,
+                    raw_request,
+                    timeout=_remaining_request_timeout(total_timeout, deadline),
+                    timeout_detail_seconds=total_timeout,
+                )
+            except HTTPException as exc:
+                tracker.finish(result=_metrics_result_from_status(exc.status_code))
+                raise
+            if outputs is None:
+                tracker.finish(result="client_closed")
+                return Response(status_code=499)  # Client closed request
+
+            elapsed = time.perf_counter() - start_time
+            total_completion = sum(o.completion_tokens for o in outputs)
+            tokens_per_sec = total_completion / elapsed if elapsed > 0 else 0
+            logger.info(
+                f"Chat completion (n={request.n}): {total_completion} tokens in {elapsed:.2f}s ({tokens_per_sec:.1f} tok/s)"
+            )
+
+            choices = []
+            for i, output in enumerate(outputs):
+                (
+                    reasoning_text,
+                    cleaned_text,
+                    tool_calls,
+                ) = _extract_reasoning_and_tool_calls(
+                    output.text,
+                    request,
+                    allow_reasoning=(
+                        getattr(request, "enable_thinking", None) is not False
+                        and prepared.json_logits_processor is None
+                    ),
+                    engine=engine,
+                )
+
+                # Process response_format if specified (per-output)
+                if prepared.response_format and not tool_calls:
+                    json_input = cleaned_text or output.text
+                    _, parsed_json, is_valid, error = parse_json_output(
+                        json_input, prepared.response_format
+                    )
+                    if parsed_json is not None:
+                        cleaned_text = json.dumps(parsed_json)
+                    if not is_valid:
+                        if prepared.json_logits_processor is not None:
+                            logger.error(
+                                "Constrained decoding produced invalid JSON: %s",
+                                error,
+                            )
+                        else:
+                            logger.warning(f"JSON validation failed: {error}")
+
+                finish_reason = "tool_calls" if tool_calls else output.finish_reason
+                choices.append(
+                    ChatCompletionChoice(
+                        index=i,
+                        message=AssistantMessage(
+                            content=(
+                                clean_output_text(cleaned_text)
+                                if cleaned_text
+                                else None
+                            ),
+                            reasoning=reasoning_text,
+                            tool_calls=tool_calls,
+                        ),
+                        finish_reason=finish_reason,
+                    )
+                )
+
+            # Count prompt tokens ONCE (shared across rollouts).
+            prompt_tokens = outputs[0].prompt_tokens
+            tracker.finish(
+                result="success",
+                prompt_tokens=prompt_tokens,
+                completion_tokens=total_completion,
+            )
+            return ChatCompletionResponse(
+                model=_model_name,
+                choices=choices,
+                usage=Usage(
+                    prompt_tokens=prompt_tokens,
+                    completion_tokens=total_completion,
+                    total_tokens=prompt_tokens + total_completion,
+                ),
+            )
 
         try:
             output = await _wait_with_disconnect(


### PR DESCRIPTION
## Summary

Adds OpenAI-compatible `n` (1..64) and `best_of` fields to `ChatCompletionRequest` and `CompletionRequest`. Handlers fan out `n` parallel rollouts via `asyncio.gather`; the default-enabled prefix cache dedups the shared prompt-KV automatically. Streaming with `n>1` is rejected (HTTP 400, `code=stream_n_unsupported`). Token accounting follows OpenAI semantics (`prompt_tokens` counted once, `completion_tokens` summed across choices). The `n=1` path is bit-identical (zero overhead).

**Plan-1.5 Patch #1 of 3.** Tracks [akaszubski/realign#1308](https://github.com/akaszubski/realign/issues/1308); parent realign#1307. Companion patches: realign#1251 (per-token logprobs, pending), realign#1309 (WeightTransferEngine, PR #5).

## ⚠️ Rebase required before merge

This branch was cut from `main@ae25fb83` and is **4 commits behind current `main@350a2234`**:
- `350a2234` docs: add .claude/PROJECT.md
- `310067b8` chore: opt out of autonomous-dev gate
- `ea9d0ce8` fix(ssd_cache): mlx-native safetensors for bf16 KV spill (#2)
- `ea7eeecd` fix(hermes): suppress malformed `<function` openers in Qwen3-Coder (#3)

The two `fix()` commits touch `vllm_mlx/ssd_cache.py` and `vllm_mlx/tool_parsers/hermes_tool_parser.py` — files this branch also touches. The current diff therefore shows misleading reverse-hotfix deltas (e.g., `-49` lines on `hermes_tool_parser.py` that are actually main's hotfix, not removals by this patch). A clean view requires rebase onto current main.

**Also conflicts with PR #5 (patch #3)** on `CHANGELOG.md` — both branches create it fresh. One PR rebases onto the other before merge.

## Test plan (validated on branch as-pushed)

- [x] 14 `TestGroupSampling` cases + 16 independent spec-validator cases pass
- [x] Full pytest gate (`test_api_models.py` + `test_responses_api.py` + new file): 0 failures, 0 errors, 0 new skips
- [x] `n=1` path bit-identical to pre-patch (zero overhead)
- [ ] Re-run pytest after rebase onto current `main` to confirm no hotfix interaction

## Known non-blocking follow-ups (from ci-analyst)

- **A04-2** (WARNING): no combined `k*n` cap on multi-prompt completions — recommend `max_length=64` on `CompletionRequest.prompt`
- **A04-4** (MEDIUM): `asyncio.gather` orphans siblings on first exception — recommend `asyncio.TaskGroup` migration. Tracked in [realign#1311](https://github.com/akaszubski/realign/issues/1311).

🤖 Generated with [Claude Code](https://claude.com/claude-code)