### PR TITLE
test+fix(rlvr): live HTTP smoke for logprobs/n + fix two wire-level bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,35 @@ this project adheres to [Semantic Versioning](https://semver.org/).
   `StartWeightUpdateRequest`, `WeightTransferUpdateRequest`, `PauseRequest`
   in `vllm_mlx/api/models.py`. (realign#1309)
 
+### Fixed
+
+- `RequestOutputCollector._merge_outputs` was silently dropping `logprobs` and
+  `new_logprobs` fields when the producer got ahead of the consumer (aggregate
+  mode). The cumulative `logprobs` array and per-step `new_logprobs` delta are
+  now propagated correctly through the merge, so logprobs are never lost on the
+  streaming buffer even when multiple tokens are coalesced before the consumer
+  drains. Exposed by the live HTTP smoke; pinned by two new unit regression
+  tests in `tests/test_logprobs_surface.py`.
+- `create_chat_completion` `n>1` branch was not threading `choice_logprobs`
+  onto each `ChatCompletionChoice`. Callers requesting `n>1` with
+  `logprobs=true` would receive `choices[*].logprobs: null` despite the engine
+  having populated logprobs on every rollout. Each rollout's cumulative
+  `output.logprobs` is now forwarded to its matching `ChatCompletionChoice`.
+
+### Tests
+
+- Live-HTTP smoke for Plan-1.5 patches #1 + #2 at
+  `tests/test_logprobs_n_live_smoke.py`. Boots a real
+  `python -m vllm_mlx.server` subprocess on an ephemeral port, waits for
+  `/health` to report `model_loaded: True`, and exercises four
+  `/v1/chat/completions` paths end-to-end: (A) `logprobs=true` populates
+  `choices[0].logprobs.content` with one entry per completion token,
+  (B) `n=4` yields four choices indexed `{0,1,2,3}`, (C) `n=4` + `logprobs=true`
+  composes correctly across all choices, (D) `top_logprobs=5` yields five
+  per-slot alternatives sorted by `logprob` non-increasing. Gated by a new
+  `live_server` pytest marker so it is opt-in; default `pytest` runs do not
+  collect it. Run with `pytest -m live_server tests/test_logprobs_n_live_smoke.py`.
+
 ### Notes
 
 - **Wired engines** (logprobs): `BatchedEngine` (continuous batching — the path
@@ -52,3 +81,8 @@ this project adheres to [Semantic Versioning](https://semver.org/).
 - Trainer-level end-to-end (`realign train --reload-every 1`) and LoRA +
   grad-step deadlock validation are tracked separately (realign#1309 follow-up);
   out of scope for these patches.
+- **realign-side bug uncovered while wiring the smoke**:
+  `realign/.../vllm_mlx_rollout.py:235` passes `max_tokens=` to
+  `vllm_mlx.Request(...)`, but `max_tokens` lives on `SamplingParams`. This
+  caused the realign GRPO smoke to silently fall back to
+  `mlx_lm.batch_generate`. Fix belongs in realign, tracked under realign#1308.

--- a/docs/guides/server.md
+++ b/docs/guides/server.md
@@ -864,3 +864,29 @@ vllm-mlx serve mlx-community/Qwen3-0.6B-8bit \
   --timeout 120 \
   --port 8000
 ```
+
+## Live HTTP smoke
+
+The repo ships an opt-in HTTP smoke test that boots a real
+`python -m vllm_mlx.server` subprocess on an ephemeral port and exercises
+`/v1/chat/completions` end-to-end. It validates the wire format for the
+two RLHF-facing features — group sampling (`n`) and per-token logprobs
+(`logprobs`, `top_logprobs`) — against a running server, complementing
+the in-memory unit coverage in `tests/test_logprobs_surface.py`.
+
+The smoke is gated behind the `live_server` pytest marker so a default
+`pytest` run does not boot a server. To run it explicitly:
+
+```bash
+pytest -m live_server tests/test_logprobs_n_live_smoke.py -v
+```
+
+Requirements:
+
+- `mlx-community/Llama-3.2-3B-Instruct-4bit` cached locally (the test skips
+  if the snapshot directory is absent).
+- A free TCP port on `127.0.0.1` (the test selects one automatically).
+
+The server is reaped on every exit path (pass, fail, KeyboardInterrupt) via
+`SIGTERM` -> 10s grace -> `SIGKILL`, so the test will not leave an orphan
+listener behind.

--- a/pytest.ini
+++ b/pytest.ini
@@ -11,12 +11,13 @@ python_functions = test_*
 markers =
     slow: marks tests as slow (require model loading, deselect with '-m "not slow"')
     integration: marks tests as integration tests (require running server)
+    live_server: opt-in HTTP smoke (boots a real server subprocess)
 
 # Default options
 addopts =
     -v
     --tb=short
-    -m "not slow and not integration"
+    -m "not slow and not integration and not live_server"
 
 # Ignore warnings from dependencies
 filterwarnings =

--- a/tests/test_logprobs_n_live_smoke.py
+++ b/tests/test_logprobs_n_live_smoke.py
@@ -1,0 +1,356 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+Live-HTTP smoke validation for Plan-1.5 patches #1 (n group sampling) and
+#2 (per-token logprobs).
+
+This module is opt-in: it is decorated with the ``live_server`` marker so
+``pytest`` does not collect it by default (see ``pytest.ini``). To run it
+explicitly::
+
+    pytest -m live_server tests/test_logprobs_n_live_smoke.py -v
+
+The fixture boots a real ``python -m vllm_mlx.server`` subprocess on an
+ephemeral free port, waits for ``/health`` to report ``model_loaded: True``,
+yields the base URL, and reaps the process on teardown (SIGTERM, then
+SIGKILL after 10s). All four tests below issue real HTTP requests against
+``/v1/chat/completions``.
+
+Why this exists: unit coverage in ``test_logprobs_surface.py`` exercises the
+schema and helpers in-memory, but does not exercise the actual end-to-end
+wire format the trainer hits. This smoke catches integration bugs the unit
+tests cannot.
+"""
+
+from __future__ import annotations
+
+import atexit
+import os
+import signal
+import socket
+import subprocess
+import sys
+import time
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+requests = pytest.importorskip("requests")
+pytest.importorskip("mlx")
+
+# Hardcoded per plan: vetted server default, present on this machine.
+MODEL_ID = "mlx-community/Llama-3.2-3B-Instruct-4bit"
+MODEL_CACHE_DIR = (
+    Path.home() / "Models" / "hub" / "models--mlx-community--Llama-3.2-3B-Instruct-4bit"
+)
+
+# Module-level marker: applied to every test in this file. The
+# ``enable_socket`` marker tells ``pytest-socket`` (a transitive test-dep
+# that disables real sockets by default) to allow real TCP for every test
+# here -- the entire module exists to talk to a real HTTP server.
+pytestmark = [pytest.mark.live_server, pytest.mark.enable_socket]
+
+
+def _pick_free_port() -> int:
+    """Bind a socket to port 0 to ask the OS for an unused port, then close it."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+
+
+def _wait_for_healthy(base_url: str, timeout_s: float = 90.0) -> dict:
+    """Poll ``GET /health`` until ``model_loaded`` is True.
+
+    Backoff: 0.5s -> 2.0s (cap). Raises ``pytest.fail`` if the server does
+    not report healthy within ``timeout_s``.
+    """
+    deadline = time.monotonic() + timeout_s
+    delay = 0.5
+    last_payload: dict | str = "<no response>"
+    last_exc: str | None = None
+    while time.monotonic() < deadline:
+        try:
+            resp = requests.get(f"{base_url}/health", timeout=5.0)
+            last_payload = resp.json() if resp.headers.get("content-type", "").startswith("application/json") else resp.text
+            if resp.status_code == 200 and isinstance(last_payload, dict) and last_payload.get("model_loaded") is True:
+                return last_payload
+        except Exception as exc:  # noqa: BLE001 - intentional broad catch while polling
+            last_exc = repr(exc)
+        time.sleep(delay)
+        delay = min(delay * 1.5, 2.0)
+    pytest.fail(
+        f"server at {base_url} did not become healthy in {timeout_s:.0f}s. "
+        f"last /health payload: {last_payload!r}; last exception: {last_exc}"
+    )
+
+
+@pytest.fixture(scope="session")
+def live_server() -> Iterator[str]:
+    """Boot a real vllm_mlx server subprocess on a free port for the test session."""
+    if not MODEL_CACHE_DIR.exists():
+        pytest.skip(
+            f"model snapshot not on disk at {MODEL_CACHE_DIR}; cache the model first"
+        )
+
+    # ``pytest-socket`` (a transitive test-dep) disables real sockets by
+    # default. This whole module's point is to talk to a real HTTP server,
+    # so re-enable sockets for the duration of the session. Best-effort:
+    # if the plugin isn't loaded the import will fail and we just continue.
+    try:
+        from pytest_socket import enable_socket  # type: ignore[import-not-found]
+
+        enable_socket()
+    except ImportError:
+        pass
+
+    port = _pick_free_port()
+    base_url = f"http://127.0.0.1:{port}"
+
+    # Capture server logs to a temp file so debug breadcrumbs survive when
+    # the test fails. Set ``VLLM_MLX_SMOKE_LOGS=1`` to print the tail on
+    # failure / teardown.
+    log_path = Path(os.environ.get("TMPDIR", "/tmp")) / f"vllm_mlx_smoke_{port}.log"
+    log_fh = open(log_path, "w", buffering=1)
+
+    # ``--continuous-batching`` is required: it selects ``BatchedEngine``,
+    # which is the only engine wired with per-token logprobs (per the
+    # patch #2 CHANGELOG note). ``SimpleEngine`` does not populate them
+    # and -- as of Python 3.14 + mlx_lm -- also crashes with a thread-bound
+    # GPU stream error inside the ``asyncio.to_thread`` worker.
+    proc = subprocess.Popen(
+        [
+            sys.executable,
+            "-m",
+            "vllm_mlx.server",
+            "--model",
+            MODEL_ID,
+            "--host",
+            "127.0.0.1",
+            "--port",
+            str(port),
+            "--continuous-batching",
+        ],
+        stdout=log_fh,
+        stderr=subprocess.STDOUT,
+        # New process group so we can SIGTERM the entire tree if needed.
+        preexec_fn=os.setsid if hasattr(os, "setsid") else None,
+    )
+
+    def _reap() -> None:
+        """Best-effort process reap; safe to call multiple times."""
+        if proc.poll() is not None:
+            return
+        try:
+            try:
+                # Signal the whole process group first, fall back to the leader.
+                if hasattr(os, "killpg"):
+                    os.killpg(os.getpgid(proc.pid), signal.SIGTERM)
+                else:
+                    proc.terminate()
+            except ProcessLookupError:
+                return
+            try:
+                proc.wait(timeout=10)
+            except subprocess.TimeoutExpired:
+                try:
+                    if hasattr(os, "killpg"):
+                        os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+                    else:
+                        proc.kill()
+                except ProcessLookupError:
+                    pass
+                proc.wait()
+        except Exception:
+            # We're in teardown; never propagate.
+            pass
+
+    # Belt-and-suspenders: ensure reap on interpreter exit even if pytest crashes.
+    atexit.register(_reap)
+
+    try:
+        _wait_for_healthy(base_url, timeout_s=90.0)
+        yield base_url
+    finally:
+        _reap()
+        try:
+            log_fh.close()
+        except Exception:
+            pass
+        # Surface the tail when debugging.
+        if os.environ.get("VLLM_MLX_SMOKE_LOGS") == "1":
+            try:
+                tail = log_path.read_text().splitlines()[-80:]
+                print(f"\n=== vllm_mlx server log tail ({log_path}) ===")
+                for line in tail:
+                    print(line)
+                print("=== end ===\n")
+            except Exception:
+                pass
+
+
+# ---------------------------------------------------------------------------
+# Helpers for chat completion requests
+# ---------------------------------------------------------------------------
+
+
+_LOGPROB_KEYS = {"token", "logprob", "bytes", "top_logprobs"}
+
+
+def _post_chat(base_url: str, payload: dict, timeout_s: float = 120.0) -> dict:
+    resp = requests.post(
+        f"{base_url}/v1/chat/completions",
+        json=payload,
+        timeout=timeout_s,
+    )
+    assert resp.status_code == 200, f"HTTP {resp.status_code}: {resp.text}"
+    return resp.json()
+
+
+def _user_msg(content: str) -> list[dict]:
+    return [{"role": "user", "content": content}]
+
+
+# ---------------------------------------------------------------------------
+# Test A: logprobs=true (no top_logprobs) -> populated content array
+# ---------------------------------------------------------------------------
+
+
+def test_logprobs_populates_content_array(live_server: str) -> None:
+    """Patch #2 acceptance: ``choices[0].logprobs.content`` matches completion_tokens.
+
+    Each entry MUST have the OpenAI-shaped keys ``{token, logprob, bytes, top_logprobs}``
+    where ``top_logprobs`` is an empty list when the request did not ask for top-k
+    (matches ``_build_choice_logprobs`` server-side behavior).
+    """
+    payload = {
+        "model": MODEL_ID,
+        "messages": _user_msg("Say the single word: hello"),
+        "max_tokens": 16,
+        "temperature": 0.0,
+        "logprobs": True,
+    }
+    body = _post_chat(live_server, payload)
+
+    assert len(body["choices"]) == 1
+    choice = body["choices"][0]
+    assert choice["logprobs"] is not None, f"logprobs missing on choice: {choice}"
+
+    content = choice["logprobs"]["content"]
+    assert isinstance(content, list) and len(content) > 0, (
+        f"empty logprobs.content: {choice['logprobs']}"
+    )
+
+    completion_tokens = body["usage"]["completion_tokens"]
+    assert len(content) == completion_tokens, (
+        f"len(content)={len(content)} != completion_tokens={completion_tokens}"
+    )
+
+    for i, entry in enumerate(content):
+        assert _LOGPROB_KEYS.issubset(entry.keys()), (
+            f"entry[{i}] missing keys; got {set(entry.keys())}"
+        )
+        assert isinstance(entry["token"], str)
+        assert isinstance(entry["logprob"], float)
+        # bytes may be None for some BPE tokens (per OpenAI spec); when present
+        # it must be a list of ints.
+        if entry["bytes"] is not None:
+            assert isinstance(entry["bytes"], list)
+            assert all(isinstance(b, int) for b in entry["bytes"])
+        # top_logprobs was not requested -> server emits an empty list
+        # (see vllm_mlx.server._build_choice_logprobs).
+        assert entry["top_logprobs"] == [], (
+            f"entry[{i}].top_logprobs should be [] when not requested; "
+            f"got {entry['top_logprobs']!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Test B: n=4 -> exactly 4 choices covering indices {0,1,2,3}
+# ---------------------------------------------------------------------------
+
+
+def test_n_group_sampling_returns_four_choices(live_server: str) -> None:
+    """Patch #1 acceptance: ``n=4`` yields 4 choices with index set ``{0,1,2,3}``."""
+    payload = {
+        "model": MODEL_ID,
+        "messages": _user_msg("Write a haiku about the ocean."),
+        "max_tokens": 32,
+        "temperature": 0.8,
+        "n": 4,
+    }
+    body = _post_chat(live_server, payload)
+
+    choices = body["choices"]
+    assert len(choices) == 4, f"expected 4 choices, got {len(choices)}"
+    indices = {c["index"] for c in choices}
+    assert indices == {0, 1, 2, 3}, f"unexpected index set: {indices}"
+
+
+# ---------------------------------------------------------------------------
+# Test C: n=4 + logprobs=True -> populated logprobs on all 4 choices
+# ---------------------------------------------------------------------------
+
+
+def test_n_with_logprobs_populates_every_choice(live_server: str) -> None:
+    """Patches #1 + #2 composed: ``n=4`` + ``logprobs=true`` -> all 4 carry logprobs."""
+    payload = {
+        "model": MODEL_ID,
+        "messages": _user_msg("List three colors."),
+        "max_tokens": 24,
+        "temperature": 0.8,
+        "n": 4,
+        "logprobs": True,
+    }
+    body = _post_chat(live_server, payload)
+
+    choices = body["choices"]
+    assert len(choices) == 4
+
+    for choice in choices:
+        assert choice["logprobs"] is not None, (
+            f"choice index={choice['index']} missing logprobs"
+        )
+        content = choice["logprobs"]["content"]
+        assert isinstance(content, list) and len(content) > 0, (
+            f"choice index={choice['index']} has empty logprobs.content"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Test D: top_logprobs=5 -> 5 entries per slot, sorted non-increasing
+# ---------------------------------------------------------------------------
+
+
+def test_top_logprobs_returns_sorted_top_k(live_server: str) -> None:
+    """Patch #2: ``top_logprobs=5`` yields exactly 5 entries per content slot,
+    sorted by ``logprob`` in non-increasing order (ties allowed)."""
+    payload = {
+        "model": MODEL_ID,
+        "messages": _user_msg("Say: yes"),
+        "max_tokens": 8,
+        "temperature": 0.0,
+        "logprobs": True,
+        "top_logprobs": 5,
+    }
+    body = _post_chat(live_server, payload)
+
+    content = body["choices"][0]["logprobs"]["content"]
+    assert len(content) > 0
+
+    for i, entry in enumerate(content):
+        top = entry["top_logprobs"]
+        assert len(top) == 5, (
+            f"entry[{i}].top_logprobs length={len(top)} (expected 5)"
+        )
+        lps = [t["logprob"] for t in top]
+        # Non-increasing: allow ties.
+        for j in range(len(lps) - 1):
+            assert lps[j] >= lps[j + 1], (
+                f"entry[{i}].top_logprobs not sorted at j={j}: "
+                f"{lps[j]} < {lps[j + 1]}"
+            )
+        for alt in top:
+            assert isinstance(alt["token"], str)
+            assert isinstance(alt["logprob"], float)
+            if alt.get("bytes") is not None:
+                assert isinstance(alt["bytes"], list)

--- a/tests/test_logprobs_surface.py
+++ b/tests/test_logprobs_surface.py
@@ -23,6 +23,7 @@ from vllm_mlx.api.models import (
     ChoiceLogprobs,
 )
 from vllm_mlx.engine.base import GenerationOutput
+from vllm_mlx.output_collector import RequestOutputCollector
 from vllm_mlx.request import RequestOutput, SamplingParams
 from vllm_mlx.scheduler import _extract_logprob_entry
 from vllm_mlx.server import _build_choice_logprobs
@@ -257,3 +258,84 @@ def test_end_to_end_shape_matches_completion_tokens():
     # Reconstructed text aligns with token decoding
     reconstructed = "".join(e.token for e in wrap.content)
     assert reconstructed == "hi world"
+
+
+# ---------------------------------------------------------------------------
+# Regression: RequestOutputCollector merge must preserve per-token logprobs.
+#
+# Before the wire-level fix, ``_merge_outputs`` only copied tokens/text and
+# dropped ``logprobs``/``new_logprobs``. On the unary chat path the engine
+# loop produces one ``RequestOutput`` per token; consumers drain via
+# ``await event.wait()`` and the collector aggregates the puts that landed
+# before the wait returned. With merge silently stripping logprobs, the
+# final drained output's ``logprobs`` field was None even though the
+# scheduler had populated it on every step. The smoke test
+# ``test_logprobs_populates_content_array`` caught it; these unit tests
+# pin the merge contract so the regression cannot creep back.
+# ---------------------------------------------------------------------------
+
+
+def _lp_entry(token: str) -> dict:
+    return {"token": token, "logprob": -0.5, "bytes": list(token.encode()), "top_logprobs": []}
+
+
+def test_collector_merge_preserves_cumulative_logprobs():
+    """Final ``logprobs`` after merge must equal the latest cumulative array."""
+    collector = RequestOutputCollector(aggregate=True)
+
+    first = RequestOutput(
+        request_id="r1",
+        new_token_ids=[1],
+        new_text="a",
+        output_token_ids=[1],
+        output_text="a",
+        new_logprobs=[_lp_entry("a")],
+        logprobs=[_lp_entry("a")],
+    )
+    second = RequestOutput(
+        request_id="r1",
+        new_token_ids=[2],
+        new_text="b",
+        output_token_ids=[1, 2],
+        output_text="ab",
+        finished=True,
+        finish_reason="stop",
+        new_logprobs=[_lp_entry("b")],
+        logprobs=[_lp_entry("a"), _lp_entry("b")],
+    )
+
+    collector.put(first)
+    collector.put(second)  # triggers _merge_outputs
+
+    merged = collector.get_nowait()
+    assert merged is not None
+    # Cumulative logprobs survive the merge
+    assert merged.logprobs is not None
+    assert [e["token"] for e in merged.logprobs] == ["a", "b"]
+    # Per-step deltas concatenated
+    assert merged.new_logprobs is not None
+    assert [e["token"] for e in merged.new_logprobs] == ["a", "b"]
+    # Tokens and finished flag still propagate
+    assert merged.new_token_ids == [1, 2]
+    assert merged.new_text == "ab"
+    assert merged.finished is True
+
+
+def test_collector_merge_leaves_logprobs_none_when_disabled():
+    """Requests that did not opt in still see ``logprobs is None`` after merge."""
+    collector = RequestOutputCollector(aggregate=True)
+
+    first = RequestOutput(request_id="r1", new_token_ids=[1], new_text="a", output_text="a")
+    second = RequestOutput(
+        request_id="r1",
+        new_token_ids=[2],
+        new_text="b",
+        output_text="ab",
+        finished=True,
+    )
+    collector.put(first)
+    collector.put(second)
+    merged = collector.get_nowait()
+    assert merged is not None
+    assert merged.logprobs is None
+    assert merged.new_logprobs is None

--- a/vllm_mlx/output_collector.py
+++ b/vllm_mlx/output_collector.py
@@ -139,6 +139,26 @@ class RequestOutputCollector:
         merged_new_token_ids = existing.new_token_ids + new.new_token_ids
         merged_new_text = existing.new_text + new.new_text
 
+        # Per-token logprobs (Plan-1.5 patch #2). ``new_logprobs`` is a
+        # per-step delta (typically length 1) and MUST be concatenated so
+        # the streaming consumer never loses tokens that were emitted while
+        # the buffer was unread. ``logprobs`` is the cumulative array on
+        # the producer side -- prefer ``new.logprobs`` since it already
+        # includes every entry up through this step; fall back to
+        # ``existing.logprobs`` if the new output didn't carry the
+        # cumulative view (defensive).
+        if existing.new_logprobs is None and new.new_logprobs is None:
+            merged_new_logprobs = None
+        else:
+            merged_new_logprobs = list(existing.new_logprobs or []) + list(
+                new.new_logprobs or []
+            )
+
+        if new.logprobs is not None:
+            merged_logprobs = new.logprobs
+        else:
+            merged_logprobs = existing.logprobs
+
         return RequestOutput(
             request_id=new.request_id,
             new_token_ids=merged_new_token_ids,
@@ -149,6 +169,8 @@ class RequestOutputCollector:
             finish_reason=new.finish_reason,
             prompt_tokens=new.prompt_tokens,
             completion_tokens=new.completion_tokens,
+            new_logprobs=merged_new_logprobs,
+            logprobs=merged_logprobs,
         )
 
     def clear(self) -> None:

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -4313,6 +4313,13 @@ async def create_chat_completion(request: ChatCompletionRequest, raw_request: Re
                             logger.warning(f"JSON validation failed: {error}")
 
                 finish_reason = "tool_calls" if tool_calls else output.finish_reason
+                # Per-token logprobs (Plan-1.5 patch #2 composed with patch #1
+                # n-group sampling). Each rollout carries its own cumulative
+                # ``output.logprobs``; surface it on the matching Choice so
+                # callers asking for ``n>1`` + ``logprobs=true`` get one
+                # populated ``choices[i].logprobs`` per rollout. Falls back to
+                # ``None`` automatically when the request didn't opt in.
+                choice_logprobs = _build_choice_logprobs(output.logprobs)
                 choices.append(
                     ChatCompletionChoice(
                         index=i,
@@ -4326,6 +4333,7 @@ async def create_chat_completion(request: ChatCompletionRequest, raw_request: Re
                             tool_calls=tool_calls,
                         ),
                         finish_reason=finish_reason,
+                        logprobs=choice_logprobs,
                     )
                 )
 


### PR DESCRIPTION
Adds an opt-in live HTTP integration test that boots `python -m vllm_mlx.server` and validates the merged Plan-1.5 patches end-to-end (acceptance criterion from realign#1251 — never actually exercised). **The smoke immediately exposed two wire-level bugs in the merged patches that no unit test caught — both now fixed with regression tests.**

## TL;DR

- **New**: 4-test live HTTP smoke (`tests/test_logprobs_n_live_smoke.py`), opt-in via `pytest -m live_server`.
- **Fixed**: 2 wire bugs in `output_collector.py` and `server.py` that caused `choices[*].logprobs: null` on the wire despite all unit tests passing.
- **Verified**: 4/4 live + 21/21 unit (incl. 2 new regression tests verified to FAIL on pre-fix code).

## New test (`tests/test_logprobs_n_live_smoke.py`)

4 tests, all `@pytest.mark.live_server` (deselected from default `pytest tests/`; opt in via `pytest -m live_server`):

| Test | What | Validates |
|---|---|---|
| A | `logprobs=true` → `choices[0].logprobs.content[]` is non-empty, `len == usage.completion_tokens`, every entry shaped `{token, logprob, bytes, top_logprobs}` | Patch #2 wire format |
| B | `n=4` → 4 distinct choices, indexes `{0,1,2,3}` | Patch #1 wire format |
| C | `n=4` + `logprobs=true` → all 4 choices have populated logprobs | Patch #1 ⊕ Patch #2 composition |
| D | `top_logprobs=5` → 5 alternatives per content entry, sorted descending | Top-k extraction |

Fixture binds an ephemeral port via `socket.bind((..., 0))`, polls `/health` for up to 90s with exponential backoff, and SIGTERMs then SIGKILLs on teardown so no zombie process survives a test failure.

## Two wire bugs the smoke caught

### Bug 1 — `vllm_mlx/output_collector.py::_merge_outputs`

Rebuilt `RequestOutput` via constructor call but never named the `logprobs=` / `new_logprobs=` fields that patch #2 added to `RequestOutput`. The dataclass defaults silently dropped them, so any time the producer buffered more than one `RequestOutput` before the consumer drained (the normal `generate()` path), the merged output returned `logprobs=None` to the engine → `_build_choice_logprobs(None)` → `null` on the wire.

### Bug 2 — `vllm_mlx/server.py::create_chat_completion` n>1 branch

Constructed each per-rollout `ChatCompletionChoice(...)` without `logprobs=`, so even with bug 1 fixed every n>1 rollout would still drop its logprobs.

**Both fixes are minimum-correct**: name the missing kwargs in two constructor calls. No new product code.

## Regression coverage

`tests/test_logprobs_surface.py` gains 2 unit tests pinning the collector merge contract. Verified to FAIL on pre-fix `output_collector.py` (`AssertionError: assert None is not None` on `merged.logprobs`) and PASS after the fix — proves they catch the actual regression, not a tautology.

## Realign-side finding (documented, not fixed here)

`realign/.../vllm_mlx_rollout.py:235` passes `max_tokens=` to `vllm_mlx.Request(...)`. `max_tokens` lives on `SamplingParams`, not `Request` — so the realign GRPO smoke silently fell back to `mlx_lm.batch_generate` and never actually exercised vllm-mlx. Fix belongs in realign (tracked in CHANGELOG `### Notes`); vllm-mlx is correct.

## Verification

```
pytest -m live_server tests/test_logprobs_n_live_smoke.py -v   # 4 passed in 7.53s
pytest tests/test_logprobs_surface.py -q                       # 21 passed (19 prior + 2 new)
pytest --collect-only tests/test_logprobs_n_live_smoke.py      # 4 deselected by default
```

## Files

| File | LOC | What |
|---|---|---|
| `tests/test_logprobs_n_live_smoke.py` | +338 | NEW — 4-test live smoke |
| `tests/test_logprobs_surface.py` | +82 | 2 regression tests |
| `vllm_mlx/output_collector.py` | +22 | Bug 1 fix |
| `vllm_mlx/server.py` | +8 | Bug 2 fix |
| `pytest.ini` | +1 | live_server marker |
| `CHANGELOG.md` | ~+30 | Tests + Fixed + Notes sections |
| `docs/guides/server.md` | +26 | Live HTTP smoke subsection |

Total: 7 files, +530/-1 LOC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)